### PR TITLE
Minor cleanup/refactor

### DIFF
--- a/mogwai/src/component.rs
+++ b/mogwai/src/component.rs
@@ -254,11 +254,9 @@ where
                 .drain(0..)
                 .collect::<Vec<_>>()
           };
-          if msgs.len() > 0 {
-            msgs.iter().for_each(|out_msg| {
-              tx_out_async.send(out_msg);
-            });
-          }
+          msgs.iter().for_each(|out_msg| {
+            tx_out_async.send(out_msg);
+          });
           false
         });
       }

--- a/mogwai/src/txrx.rs
+++ b/mogwai/src/txrx.rs
@@ -423,8 +423,8 @@ fn recv_from<A>(
 
   Receiver {
     k,
-    next_k: next_k.clone(),
-    branches: branches.clone()
+    next_k,
+    branches
   }
 }
 

--- a/mogwai/src/txrx.rs
+++ b/mogwai/src/txrx.rs
@@ -431,7 +431,7 @@ fn recv_from<A>(
 /// Send messages instantly.
 pub struct Transmitter<A> {
   next_k: Rc<Cell<usize>>,
-  branches: Rc<RefCell<HashMap<usize, Box<dyn FnMut(&A)>>>>,
+  branches: RecvResponders<A>,
 }
 
 
@@ -450,7 +450,7 @@ impl<A:Any> Transmitter<A> {
   pub fn new() -> Transmitter<A> {
     Transmitter {
       next_k: Rc::new(Cell::new(0)),
-      branches: Rc::new(RefCell::new(HashMap::new()))
+      branches: RecvResponders::default(),
     }
   }
 
@@ -703,7 +703,7 @@ impl<A:Any> Transmitter<A> {
 pub struct Receiver<A> {
   k: usize,
   next_k: Rc<Cell<usize>>,
-  branches: Rc<RefCell<HashMap<usize, Box<dyn FnMut(&A)>>>>,
+  branches: RecvResponders<A>,
 }
 
 
@@ -731,7 +731,7 @@ impl<A> Receiver<A> {
     Receiver {
       k: 0,
       next_k: Rc::new(Cell::new(1)),
-      branches: Rc::new(RefCell::new(HashMap::new()))
+      branches: RecvResponders::default(),
     }
   }
 


### PR DESCRIPTION
While trying to port some optimizations from other wasm frameworks, I noticed some little things that could be improved. Unfortunately I failed to improve performance on todomvc, but I figured these changes might be useful.

(For posterity, I tried: caching `window()`/`document()`/`body()`; [interning](https://docs.rs/wasm-bindgen/0.2.62/wasm_bindgen/fn.intern.html) element names and other common strings; and using `slab`/`vec_map` instead of `HashMap` in `RecvResponders`. It's hard to get good profiling data for wasm because Chrome seems to attribute a lot of time to nothing and Firefox's profiler is hard to navigate, but interning _ought_ to be profitable, because FF's profiler shows `getStringFromWasm0` as one of the most frequent JS calls.)