### PR TITLE
setTimeout(callback, 0) does not run the callback immediately

### DIFF
--- a/mogwai/Cargo.toml
+++ b/mogwai/Cargo.toml
@@ -30,6 +30,8 @@ features = [
   "EventTarget",
   "HtmlElement",
   "HtmlInputElement",
+  "MessageChannel",
+  "MessagePort",
   "Node",
   "Text",
   "Window"

--- a/mogwai/src/component.rs
+++ b/mogwai/src/component.rs
@@ -254,11 +254,9 @@ where
                 .drain(0..)
                 .collect::<Vec<_>>()
           };
-          if msgs.len() > 0 {
-            msgs.iter().for_each(|out_msg| {
-              tx_out_async.send(out_msg);
-            });
-          }
+          msgs.iter().for_each(|out_msg| {
+            tx_out_async.send(out_msg);
+          });
           false
         });
       }

--- a/mogwai/src/component.rs
+++ b/mogwai/src/component.rs
@@ -232,34 +232,10 @@ where
       T::update(&mut t, msg, &tx_view, &subscriber);
     });
 
-    let out_msgs = Rc::new(RefCell::new(vec![]));
     rx_view.respond(move |msg: &T::ViewMsg| {
-      let should_schedule =
-        {
-        let mut msgs = out_msgs.borrow_mut();
-        msgs.push(msg.clone());
-        // If there is more than just this message in the queue, this
-        // responder has already been run this frame and a timer has
-        // already been scheduled, so there's no need to schedule another
-        msgs.len() == 1
-      };
-      if should_schedule {
-        let out_msgs_async = out_msgs.clone();
-        let tx_out_async = tx_out.clone();
-        utils::timeout(0, move || {
-          let msgs =
-            {
-              out_msgs_async
-                .borrow_mut()
-                .drain(0..)
-                .collect::<Vec<_>>()
-          };
-          msgs.iter().for_each(|out_msg| {
-            tx_out_async.send(out_msg);
-          });
-          false
-        });
-      }
+      let tx_out = tx_out.clone();
+      let msg = msg.clone();
+      utils::set_immediate(move || tx_out.send(&msg));
     });
 
     let gizmo = {

--- a/mogwai/src/txrx.rs
+++ b/mogwai/src/txrx.rs
@@ -423,8 +423,8 @@ fn recv_from<A>(
 
   Receiver {
     k,
-    next_k: next_k.clone(),
-    branches: branches.clone()
+    next_k,
+    branches
   }
 }
 

--- a/mogwai/src/txrx.rs
+++ b/mogwai/src/txrx.rs
@@ -431,7 +431,7 @@ fn recv_from<A>(
 /// Send messages instantly.
 pub struct Transmitter<A> {
   next_k: Rc<Cell<usize>>,
-  branches: Rc<RefCell<HashMap<usize, Box<dyn FnMut(&A)>>>>,
+  branches: RecvResponders<A>,
 }
 
 
@@ -450,7 +450,7 @@ impl<A:Any> Transmitter<A> {
   pub fn new() -> Transmitter<A> {
     Transmitter {
       next_k: Rc::new(Cell::new(0)),
-      branches: Rc::new(RefCell::new(HashMap::new()))
+      branches: RecvResponders::default(),
     }
   }
 
@@ -703,7 +703,7 @@ impl<A:Any> Transmitter<A> {
 pub struct Receiver<A> {
   k: usize,
   next_k: Rc<Cell<usize>>,
-  branches: Rc<RefCell<HashMap<usize, Box<dyn FnMut(&A)>>>>,
+  branches: RecvResponders<A>,
 }
 
 
@@ -731,7 +731,7 @@ impl<A> Receiver<A> {
     Receiver {
       k: 0,
       next_k: Rc::new(Cell::new(1)),
-      branches: Rc::new(RefCell::new(HashMap::new()))
+      branches: RecvResponders::default(),
     }
   }
 


### PR DESCRIPTION
Based on #23, although it's not required.

`setTimeout(callback, 0)` is roughly the same as `setTimeout(callback, 4)`, see https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout#Reasons_for_delays_longer_than_specified. IE and Node implement a `setImmediate` function that behaves like you'd expect `setTimeout(0)` to, but there is _still_ no standard way to do this in modern browsers... So people use various hacks based on MutationObserver, sending messages to the current window, or MessageChannel (what I use here).

This slightly improves performance on todomvc (10 runs, Chrome 81):
![image](https://user-images.githubusercontent.com/7673145/83338917-e17bc300-a296-11ea-9fab-65b407b0d46f.png)

But...wait. That seems like an awfully small improvement. It turns out the benchmark harness also uses `setTimeout(0)` (https://github.com/schell/todo-mvc-bench/pull/42), so it doesn't measure stuff accurately.

With that fixed, this significantly improves performance on todomvc (10 runs, Chrome 81):
![image](https://user-images.githubusercontent.com/7673145/83338981-66ff7300-a297-11ea-90e6-1af1493d9845.png)

In Firefox, there is still an improvement but it's much smaller (10 runs, Firefox 76):
![image](https://user-images.githubusercontent.com/7673145/83339165-12f58e00-a299-11ea-8bc0-2035b706271c.png)