### PR TITLE
Update wasm_bindgen to be not on window ctx

### DIFF
--- a/examples/sandbox/src/lib.rs
+++ b/examples/sandbox/src/lib.rs
@@ -88,8 +88,7 @@ pub fn new_h1_gizmo(mut tx_click:Transmitter<Event>) -> Gizmo<HtmlElement> {
 async fn request_to_text(req:Request) -> Result<String, String> {
   let resp:Response =
     JsFuture::from(
-      window()
-        .fetch_with_request(&req)
+        fetch_with_request(&req)
     )
     .await
     .map_err(|_| "request failed".to_string())?


### PR DESCRIPTION
**Note:** I'm a Rust noob and I don't know how to test this change. Please use only as a prompt.

**Recreate:**
- `cargo generate --git https://github.com/schell/mogwai-template.git`
- `wasm-pack build --target no-modules`
- `basic-http-server -a 127.0.0.1:8888`

**ERROR:**
```
Uncaught TypeError: window.wasm_bindgen is not a function
    at (index):12
```


**Problem:**
`wasm_bindgen` isn't applied onto `window` and therefore `window.wasm_bindgen` will throw error on when building targets:

HTML Before:

```
<!DOCTYPE html>
<html lang="en">
    <head>
        <meta charset="utf-8">
        <title>demo2</title>
        <link rel="stylesheet" href="style.css">
    </head>
    <body>
        <script src="pkg/demo.js"></script>
        <script type=module>
         window
             .wasm_bindgen('pkg/demo_bg.wasm')
             .then( m => m.main() )
             .catch(console.error);
        </script>
    </body>
</html>
```

HTML After:

```
<!DOCTYPE html>
<html lang="en">
    <head>
        <meta charset="utf-8">
        <title>demo2</title>
        <link rel="stylesheet" href="style.css">
    </head>
    <body>
        <script src="pkg/demo.js"></script>
        <script type=module>
             wasm_bindgen('pkg/demo_bg.wasm')
             .then( m => m.main() )
             .catch(console.error);
        </script>
    </body>
</html>
```


An alternative is to pass window into the bundled IFFE of `pkg/demo.js`

**BEFORE:**

```
let wasm_bindgen;
(function() {
//...

wasm_bindgen = Object.assign(init, __exports);
})()

```

**After**

```
let wasm_bindgen;
(function() {
// ...

wasm_bindgen = Object.assign(init, __exports);
})(window) // pass window in

```