### PR TITLE
Less alloc, mutable API instead of builder pattern

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,15 +1,12 @@
-name: cicd
+name: "on pull request"
 
 on: pull_request
 
 jobs:
-  build:
-
+- mogwai:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v1
-
     # caching
     - name: Cache .cargo
       uses: actions/cache@v2
@@ -18,21 +15,37 @@ jobs:
           ~/.cargo
           /usr/share/rust/.cargo/bin
           target
-          cookbook_target
         key: ${{ runner.os }}-cargo-all-${{ github.ref }}
         restore-keys: |
           ${{ runner.os }}-cargo-all-refs/heads/master
           ${{ runner.os }}-cargo-all-
-
     - name: build
       run: scripts/build.sh
-
     - name: test
       run: scripts/test.sh
-
     - name: "release to crates-io"
       if: startsWith(github.ref, 'refs/tags/v')
       run: |
         cd crates/mogwai-html-macro && cargo publish --token ${{ secrets.cargo_token }}
         cd ../..
         cd mogwai && cargo publish --token ${{ secrets.cargo_token }}
+
+- cookbook:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    # caching
+    - name: Cache .cargo
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo
+          /usr/share/rust/.cargo/bin
+          target
+        key: ${{ runner.os }}-cargo-all-${{ github.ref }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-cookbook-refs/heads/master
+          ${{ runner.os }}-cargo-cookbook-
+          ${{ runner.os }}-cargo-all-
+    - name: test
+      run: scripts/test_cookbook.sh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,7 @@ name: "on pull request"
 on: pull_request
 
 jobs:
-- mogwai:
+  mogwai:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -30,7 +30,7 @@ jobs:
         cd ../..
         cd mogwai && cargo publish --token ${{ secrets.cargo_token }}
 
-- cookbook:
+  cookbook:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,7 +42,7 @@ jobs:
           ~/.cargo
           /usr/share/rust/.cargo/bin
           target
-        key: ${{ runner.os }}-cargo-all-${{ github.ref }}
+        key: ${{ runner.os }}-cargo-cookbook-${{ github.ref }}
         restore-keys: |
           ${{ runner.os }}-cargo-cookbook-refs/heads/master
           ${{ runner.os }}-cargo-cookbook-

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,7 +41,6 @@ jobs:
         path: |
           ~/.cargo
           /usr/share/rust/.cargo/bin
-          target
         key: ${{ runner.os }}-cargo-cookbook-${{ github.ref }}
         restore-keys: |
           ${{ runner.os }}-cargo-cookbook-refs/heads/master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags: v*.*.*
 
 jobs:
-- mogwai:
+  mogwai:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: "on release"
+
+on:
+  push:
+    tags: v*.*.*
+
+jobs:
+- mogwai:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    # caching
+    - name: Cache .cargo
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo
+          /usr/share/rust/.cargo/bin
+          target
+        key: ${{ runner.os }}-cargo-all-${{ github.ref }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-all-refs/heads/master
+          ${{ runner.os }}-cargo-all-
+    - name: "release to crates-io"
+      run: |
+        cd crates/mogwai-html-macro && cargo publish --token ${{ secrets.cargo_token }}
+        cd ../../mogwai && cargo publish --token ${{ secrets.cargo_token }}
+        cd ../crates/mogwai-hydrator && cargo publish --token ${{ secrets.cargo_token }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
 name: cicd
 
-on: push
+on: push, pull_request
 
 jobs:
   build:
@@ -30,7 +30,7 @@ jobs:
       run: scripts/test.sh
 
     - name: "release to crates-io"
-      if: startsWith(github.ref, 'refs/tags/')
+      if: startsWith(github.ref, 'refs/tags/v')
       run: |
         cd crates/mogwai-html-macro && cargo publish --token ${{ secrets.cargo_token }}
         cd ../..

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,7 @@ jobs:
           ~/.cargo
           /usr/share/rust/.cargo/bin
           target
+          cookbook_target
         key: ${{ runner.os }}-cargo-all-${{ github.ref }}
         restore-keys: |
           ${{ runner.os }}-cargo-all-refs/heads/master

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,6 @@
 name: cicd
 
-on: push, pull_request
+on: pull_request
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+cookbook_target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "crates/mogwai-hydrator",
   "examples/sandbox",
   "examples/todomvc",
+  "examples/multipage",
   "cookbook"
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
   "mogwai",
   "crates/mogwai-html-macro",
+  "crates/mogwai-hydrator",
   "examples/sandbox",
   "examples/todomvc",
   #"cookbook"
@@ -11,4 +12,4 @@ members = [
 
 [profile.release]
 lto = true
-opt-level = 3
+opt-level = 'z'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
   "crates/mogwai-hydrator",
   "examples/sandbox",
   "examples/todomvc",
-  #"cookbook"
+  "cookbook"
 ]
 
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ let mut gizmo = Gizmo::from(Button{ clicks: 0 });
 gizmo.update(&ButtonIn::Click);
 gizmo.update(&ButtonIn::Click);
 
-assert_eq!(&gizmo.view_ref().clone().into_html_string(), "<button>Clicked 2 times</button>");
+assert_eq!(&gizmo.view_ref().clone().html_string(), "<button>Clicked 2 times</button>");
 
 if cfg!(target_arch = "wasm32") {
     // running a gizmo adds its DOM to document.body and ownership is passed to the window

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ impl Component for Button {
         }
     }
 
+    // Notice that the `Component::view` function returns a `ViewBuilder<T>` and not
+    // a `View<T`.
     fn view(
         &self,
         tx: &Transmitter<ButtonIn>,
@@ -151,10 +153,9 @@ impl Component for Button {
 
 let mut gizmo = Gizmo::from(Button{ clicks: 0 });
 
-// Pass some messages in to update the view, as if the button had been
-// clicked.
-gizmo.update(&ButtonIn::Click);
-gizmo.update(&ButtonIn::Click);
+// Pass some messages into the component, as if the button had been clicked:
+gizmo.send(&ButtonIn::Click);
+gizmo.send(&ButtonIn::Click);
 
 assert_eq!(&gizmo.view_ref().clone().html_string(), "<button>Clicked 2 times</button>");
 

--- a/cookbook/Cargo.toml
+++ b/cookbook/Cargo.toml
@@ -7,12 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-
-[dev-dependencies]
-doc-comment = "^0.3"
 mogwai = { path = "../mogwai", version = "^0.3" }
 
-[dev-dependencies.web-sys]
+[dependencies.web-sys]
 version = "^0.3"
 features = [
 ]

--- a/cookbook/Cargo.toml
+++ b/cookbook/Cargo.toml
@@ -3,14 +3,16 @@ name = "cookbook"
 version = "0.1.0"
 authors = ["Schell <efsubenovex@gmail.com>"]
 edition = "2018"
-build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 
-[build-dependencies]
-skeptic = "0.13"
-
 [dev-dependencies]
-skeptic = "0.13"
+doc-comment = "^0.3"
+mogwai = { path = "../mogwai", version = "^0.3" }
+
+[dev-dependencies.web-sys]
+version = "^0.3"
+features = [
+]

--- a/cookbook/Cargo.toml
+++ b/cookbook/Cargo.toml
@@ -13,3 +13,6 @@ mogwai = { path = "../mogwai", version = "^0.3" }
 version = "^0.3"
 features = [
 ]
+
+[dev-dependencies]
+doc-comment = "^0.3"

--- a/cookbook/build.rs
+++ b/cookbook/build.rs
@@ -1,7 +1,0 @@
-use skeptic::*;
-
-fn main() {
-  // Add all markdown files in directory "book/".
-  let mdbook_files = markdown_files_of_directory("src/");
-  generate_doc_tests(&mdbook_files);
-}

--- a/cookbook/src/SUMMARY.md
+++ b/cookbook/src/SUMMARY.md
@@ -3,3 +3,4 @@
 - [Intro](./intro.md)
 - [Starting a new project](new_project.md)
 - [Creating a component](component.md)
+- [Nesting components](nest_component.md)

--- a/cookbook/src/component.md
+++ b/cookbook/src/component.md
@@ -15,6 +15,9 @@ is the top-level of its gizmo hierarchy, you can run it with `run()`.
 In the following example we assume it is the top-level gizmo in the program.
 
 ```rust
+extern crate mogwai;
+extern crate web_sys;
+
 use mogwai::prelude::*;
 
 #[derive(Clone)]

--- a/cookbook/src/component.md
+++ b/cookbook/src/component.md
@@ -1,18 +1,25 @@
 # Components
-A [Component][component] is a fold function (logic), a state variable and a [View][view]
+A [Component][component] is a fold function (logic), a state variable and a [ViewBuilder][builder]
 all wrapped up in one, for your convenience!
 
 ## Creating a Component
 A mogwai component can be created by implementing the [Component][component]
 trait for any type. That type is the state. Its [Component::update][update] function
-is the logic. The [Component::view][view] function becomes the view. Use
-[Gizmo::from][gizmo_from] to turn your type into a [Gizmo][gizmo], which can be
-`run` or used however you like.
+is the logic. The [Component::view][view] function returns a builder that becomes the view
+(or views). There are a couple steps to set up the model-view-controller scenario:
 
-If your component is the top-level gizmo in your application, or if it simply
-is the top-level of its gizmo hierarchy, you can run it with `run()`.
+  1. Use [Gizmo::from][gizmo_from] to turn your state type into a [Gizmo][gizmo]
+     `let gizmo = Gizmo::from(my_data);`
+  2. Create a view using a builder from the gizmo
+     `let view = View::from(gizmo.view_builder());`
+  3. Run the view and communicate with it using the gizmo
+     ```rust,ignore
+     view.run().unwrap_throw();
+     gizmo.send(&MyMessage);
+     ```
 
-In the following example we assume it is the top-level gizmo in the program.
+Alternatively, if you don't have a need to communicate with your view you can create a view
+directly from the gizmo with `let view = View::from(gizmo);`.
 
 ```rust
 extern crate mogwai;
@@ -69,8 +76,9 @@ impl Component for App {
 
 pub fn main() -> Result<(), JsValue> {
     let gizmo: Gizmo<App> = Gizmo::from(App{ num_clicks: 0 });
+    let view = View::from(gizmo);
     if cfg!(target_arch = "wasm32") {
-        gizmo.run()
+        view.run()
     } else {
         Ok(())
     }

--- a/cookbook/src/lib.rs
+++ b/cookbook/src/lib.rs
@@ -1,0 +1,16 @@
+//! # Cookbook
+
+#[cfg(doctest)]
+doc_comment::doctest!("component.md", component_md);
+
+/// A cookbook
+pub fn cookbook() {
+    println!("Hello, world!");
+}
+
+#[cfg(test)]
+mod my_tests {
+    #[test]
+    fn can_test() {
+    }
+}

--- a/cookbook/src/lib.rs
+++ b/cookbook/src/lib.rs
@@ -4,7 +4,7 @@
 doc_comment::doctest!("component.md", component_md);
 
 #[cfg(doctest)]
-doc_comment::doctest!("nest_component.md", component_md);
+doc_comment::doctest!("nest_component.md", nest_component_md);
 
 /// A cookbook
 pub fn cookbook() {

--- a/cookbook/src/lib.rs
+++ b/cookbook/src/lib.rs
@@ -3,6 +3,9 @@
 #[cfg(doctest)]
 doc_comment::doctest!("component.md", component_md);
 
+#[cfg(doctest)]
+doc_comment::doctest!("nest_component.md", component_md);
+
 /// A cookbook
 pub fn cookbook() {
     println!("Hello, world!");

--- a/cookbook/src/main.rs
+++ b/cookbook/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/cookbook/src/nest_component.md
+++ b/cookbook/src/nest_component.md
@@ -1,0 +1,119 @@
+# Nesting components
+Naturally your app will likely nest components. The simplest way to nest components is by
+maintaining a [Gizmo](gizmo) in your component. Then spawn a builder from that sub-component field in your
+component's [Gizmo::view](gizmo_view) function to add the sub-component's view to your component's DOM.
+
+```rust
+extern crate mogwai;
+extern crate web_sys;
+
+use mogwai::prelude::*;
+
+#[derive(Clone)]
+enum CounterIn {
+    Click,
+    Reset
+}
+
+#[derive(Clone)]
+enum CounterOut {
+    DrawClicks(i32)
+}
+
+struct Counter {
+    num_clicks: i32,
+}
+
+impl Component for Counter {
+    type ModelMsg = CounterIn;
+    type ViewMsg = CounterOut;
+    type DomNode = HtmlElement;
+
+    fn view(&self, tx: &Transmitter<CounterIn>, rx: &Receiver<CounterOut>) -> ViewBuilder<HtmlElement> {
+        builder!{
+            <button on:click=tx.contra_map(|_| CounterIn::Click)>
+            {(
+                "clicks = 0",
+                rx.branch_map(|msg| {
+                    match msg {
+                        CounterOut::DrawClicks(n) => {
+                            format!("clicks = {}", n)
+                        }
+                    }
+                })
+            )}
+            </button>
+        }
+    }
+
+    fn update(&mut self, msg: &CounterIn, tx_view: &Transmitter<CounterOut>, _sub: &Subscriber<CounterIn>) {
+        match msg {
+            CounterIn::Click => {
+                self.num_clicks += 1;
+                tx_view.send(&CounterOut::DrawClicks(self.num_clicks));
+            }
+            CounterIn::Reset => {
+                self.num_clicks = 0;
+                tx_view.send(&CounterOut::DrawClicks(0));
+            }
+        }
+    }
+}
+
+
+#[derive(Clone)]
+enum In {
+    Click
+}
+
+
+#[derive(Clone)]
+enum Out {}
+
+
+struct App {
+    counter: Gizmo<Counter>
+}
+
+
+impl Default for App {
+    fn default() -> Self {
+        let counter: Gizmo<Counter> = Gizmo::from(Counter { num_clicks: 0 });
+        App{ counter }
+    }
+}
+
+
+impl Component for App {
+    type ModelMsg = In;
+    type ViewMsg = Out;
+    type DomNode = HtmlElement;
+
+    fn view(&self, tx: &Transmitter<In>, rx: &Receiver<Out>) -> ViewBuilder<HtmlElement> {
+        builder!{
+            <div>
+                {self.counter.view_builder()}
+                <button on:click=tx.contra_map(|_| In::Click)>"Click to reset"</button>
+            </div>
+        }
+    }
+
+    fn update(&mut self, msg: &In, tx_view: &Transmitter<Out>, _sub: &Subscriber<In>) {
+        match msg {
+            In::Click => {
+                self.counter.send(&CounterIn::Reset);
+            }
+        }
+    }
+}
+
+
+pub fn main() -> Result<(), JsValue> {
+    let view = View::from(Gizmo::from(App::default()));
+    if cfg!(target_arch = "wasm32") {
+        view.run()
+    } else {
+        Ok(())
+    }
+}
+```

--- a/cookbook/tests/skeptic.rs
+++ b/cookbook/tests/skeptic.rs
@@ -1,1 +1,0 @@
-include!{concat!{env!("OUT_DIR"), "/skeptic-tests.rs"}}

--- a/crates/mogwai-html-macro/src/lib.rs
+++ b/crates/mogwai-html-macro/src/lib.rs
@@ -168,7 +168,7 @@ fn node_to_view_token_stream(node: Node) -> Result<proc_macro2::TokenStream, Err
 
 fn node_to_hydrateview_token_stream(node: Node) -> Result<proc_macro2::TokenStream, Error> {
     walk_node(
-        quote!{ mogwai::prelude::Hydrator },
+        quote!{ mogwai_hydrator::Hydrator },
         node_to_hydrateview_token_stream,
         node,
     )

--- a/crates/mogwai-html-macro/src/lib.rs
+++ b/crates/mogwai-html-macro/src/lib.rs
@@ -40,6 +40,9 @@ fn attribute_to_token_stream(node: Node) -> Result<proc_macro2::TokenStream, Err
                 ["boolean", name] => Ok(quote! {
                     __mogwai_node.boolean_attribute(#name, #expr);
                 }),
+                ["this", "later"] => Ok(quote! {
+                    __mogwai_node.this_later(#expr);
+                }),
                 [attribute_name] => Ok(quote! {
                     __mogwai_node.attribute(#attribute_name, #expr);
                 }),

--- a/crates/mogwai-html-macro/src/lib.rs
+++ b/crates/mogwai-html-macro/src/lib.rs
@@ -168,7 +168,7 @@ fn node_to_view_token_stream(node: Node) -> Result<proc_macro2::TokenStream, Err
 
 fn node_to_hydrateview_token_stream(node: Node) -> Result<proc_macro2::TokenStream, Error> {
     walk_node(
-        quote!{ mogwai::prelude::HydrateView },
+        quote!{ mogwai::prelude::Hydrator },
         node_to_hydrateview_token_stream,
         node,
     )
@@ -222,7 +222,7 @@ pub fn view(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
 
 #[proc_macro]
-/// Uses an html description to construct a [`HydrateView`], which can then be converted
+/// Uses an html description to construct a [`Hydrator`], which can then be converted
 /// into a [`View`] with [`std::convert::TryFrom`].
 pub fn hydrate(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     proc_macro::TokenStream::from(walk_dom(input, node_to_hydrateview_token_stream))

--- a/crates/mogwai-html-macro/tests/integration_test.rs
+++ b/crates/mogwai-html-macro/tests/integration_test.rs
@@ -21,11 +21,14 @@ fn node_self_closing_gt_1_att() {
 
 #[test]
 fn by_hand() {
-    let _div: String = (View::element("a") as View<web_sys::HtmlElement>)
-        .attribute("href", "http://zyghost.com")
-        .attribute("class", "a_link")
-        .with(View::from("a text node"))
-        .into_html_string();
+    let mut div: View<HtmlElement> = View::element("a");
+    div.attribute("href", "http://zyghost.com");
+    div.attribute("class", "a_link");
+    div.with(View::from("a text node"));
+    assert_eq!(
+        r#"<a href="http://zyghost.com" class="a_link">a text node</a>"#,
+        &div.into_html_string()
+    );
 }
 
 

--- a/crates/mogwai-html-macro/tests/integration_test.rs
+++ b/crates/mogwai-html-macro/tests/integration_test.rs
@@ -7,14 +7,14 @@ fn node_self_closing() {
     let div: String = view! {
         <a href="http://zyghost.com" />
     }
-    .into_html_string();
+    .html_string();
     assert_eq!(&div, r#"<a href="http://zyghost.com" />"#);
 }
 
 
 #[test]
 fn node_self_closing_gt_1_att() {
-    let div: String = view! {<a href="http://zyghost.com" class="blah"/>}.into_html_string();
+    let div: String = view! {<a href="http://zyghost.com" class="blah"/>}.html_string();
     assert_eq!(&div, r#"<a href="http://zyghost.com" class="blah" />"#);
 }
 
@@ -27,7 +27,7 @@ fn by_hand() {
     div.with(View::from("a text node"));
     assert_eq!(
         r#"<a href="http://zyghost.com" class="a_link">a text node</a>"#,
-        &div.into_html_string()
+        &div.html_string()
     );
 }
 
@@ -37,7 +37,7 @@ fn node() {
     let div: String = view! {
         <a href="http://zyghost.com" class = "a_link">"a text node"</a>
     }
-    .into_html_string();
+    .html_string();
     assert_eq!(
         &div,
         r#"<a href="http://zyghost.com" class="a_link">a text node</a>"#
@@ -51,7 +51,7 @@ fn block_in_text() {
     let s: String = view! {
         <pre>"just a string with the number" {&format!("{}", x)} "<- blah blah"</pre>
     }
-    .into_html_string();
+    .html_string();
 
     assert_eq!(
         s,
@@ -66,7 +66,7 @@ fn block_at_end_of_text() {
     let s: String = view! {
         <pre>"just a string with the number" {&format!("{}", x)}</pre>
     }
-    .into_html_string();
+    .html_string();
 
     assert_eq!(&s, "<pre>just a string with the number 66</pre>");
 }
@@ -77,7 +77,7 @@ fn lt_in_text() {
     let s: String = view! {
         <pre>"this is text <- text"</pre>
     }
-    .into_html_string();
+    .html_string();
 
     assert_eq!(s, "<pre>this is text &lt;- text</pre>");
 }
@@ -93,5 +93,5 @@ fn allow_attributes_on_next_line() {
             "A string"
         </div>
     }
-    .into_html_string();
+    .html_string();
 }

--- a/crates/mogwai-hydrator/Cargo.toml
+++ b/crates/mogwai-hydrator/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "mogwai-hydrator"
+version = "0.1.0"
+authors = ["Schell Scivally <efsubenovex@gmail.com>"]
+edition = "2018"
+description = "View hydration for the mogwai library"
+repository = "https://github.com/schell/mogwai"
+readme = "../../README.md"
+keywords = ["ui", "dom", "app", "reactive", "frontend"]
+categories = ["gui", "wasm", "web-programming"]
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+mogwai = { path = "../../mogwai", version = "^0.3" }
+snafu = "^0.6"
+wasm-bindgen = "^0.2"
+
+[dependencies.web-sys]
+version = "^0.3"
+features = [
+  "Element",
+  "EventTarget",
+  "HtmlElement",
+  "Node",
+  "Text",
+]

--- a/crates/mogwai-hydrator/src/lib.rs
+++ b/crates/mogwai-hydrator/src/lib.rs
@@ -1,6 +1,6 @@
 //! Types and [`TryFrom`] instances that can 're-animate' views or portions of views from the DOM.
 use mogwai::{
-    prelude::{Component, Effect, Gizmo, IsDomNode, Receiver, Transmitter, View},
+    prelude::{Effect, IsDomNode, Receiver, Transmitter, View},
     utils,
     view::{builder::*, interface::*},
 };
@@ -168,18 +168,6 @@ impl<T: IsDomNode + AsRef<JsValue>> Hydrator<T> {
                 _ => None,
             },
         }
-    }
-
-    /// Hydrates a new [`Gizmo`] from a stateful [`Component`].
-    /// If the view cannot be hydrated an error is returned.
-    pub fn gizmo<C: Component>(init: C) -> Result<Gizmo<C>, Error> {
-        let tx_in = Transmitter::new();
-        let rx_out = Receiver::new();
-        let view_builder = init.view(&tx_in, &rx_out);
-        let hydrated = Hydrator::from(view_builder);
-        let view = View::try_from(hydrated)?;
-
-        Ok(Gizmo::from_parts(init, tx_in, rx_out, view))
     }
 }
 

--- a/crates/mogwai-hydrator/src/lib.rs
+++ b/crates/mogwai-hydrator/src/lib.rs
@@ -4,8 +4,7 @@ use mogwai::{
     utils,
     view::{builder::*, interface::*},
 };
-use snafu::{OptionExt, ResultExt, Snafu};
-use std::{cell::RefCell, rc::Rc};
+use snafu::{OptionExt, Snafu};
 pub use std::{convert::TryFrom, ops::Deref};
 pub use wasm_bindgen::{JsCast, JsValue, UnwrapThrowExt};
 pub use web_sys::{Element, Event, EventTarget, HtmlElement, HtmlInputElement};
@@ -155,7 +154,7 @@ impl<T: IsDomNode + AsRef<JsValue>> Hydrator<T> {
                     let view = view.clone();
                     match view.try_cast::<T>() {
                         Ok(mut prev_view) => {
-                            prev_update(&mut prev_view);
+                            prev_update(&mut prev_view)?;
                             Ok(())
                         }
                         Err(view) => Conversion {
@@ -535,17 +534,6 @@ where
             v.store_view(child_view.upcast());
             Ok(())
         });
-    }
-}
-
-
-impl<P, C> ParentView<(Hydrator<C>, Receiver<View<C>>)> for Hydrator<P>
-where
-    P: IsDomNode + AsRef<Node>,
-    C: IsDomNode + AsRef<Node>,
-{
-    fn with(&mut self, (child, rx): (Hydrator<C>, Receiver<View<C>>)) {
-        todo!()
     }
 }
 

--- a/examples/multipage/Cargo.toml
+++ b/examples/multipage/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "multipage"
+version = "0.1.0"
+authors = ["Bryan Swift <bryan@bryanjswift.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["console_error_panic_hook"]
+
+[dependencies]
+console_log = "^0.1"
+log = "^0.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+wasm-bindgen = "^0.2"
+
+# The `console_error_panic_hook` crate provides better debugging of panics by
+# logging them with `console.error`. This is great for development, but requires
+# all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
+# code size when deploying.
+console_error_panic_hook = { version = "0.1.6", optional = true }
+
+# `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
+# compared to the default allocator's ~10K. It is slower than the default
+# allocator, however.
+#
+# Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
+wee_alloc = { version = "0.4.2", optional = true }
+
+[dependencies.mogwai]
+path = "../../mogwai"
+
+[dependencies.web-sys]
+version = "^0.3"
+features = [
+  "HashChangeEvent",
+  "HtmlInputElement",
+  "KeyboardEvent",
+  "Location",
+  "Storage"
+]
+
+[dev-dependencies]
+wasm-bindgen-test = "^0.2"

--- a/examples/multipage/README.md
+++ b/examples/multipage/README.md
@@ -1,0 +1,4 @@
+# Multi Screen Example
+
+A simple example that serves two "routes". Each "route" changes the main
+`View` displayed by the `Gizmo`.

--- a/examples/multipage/index.html
+++ b/examples/multipage/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Mogwai • Multipage</title>
+    </head>
+    <body>
+        <script type="module">
+        import init from './pkg/multipage.js';
+            window.addEventListener('load', async () => {
+                await init();
+            });
+        </script>
+    </body>
+</html>

--- a/examples/multipage/src/app.rs
+++ b/examples/multipage/src/app.rs
@@ -1,0 +1,88 @@
+use crate::routes;
+use mogwai::prelude::*;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Route {
+    Home,
+    NotFound,
+}
+
+impl From<Route> for View<HtmlElement> {
+    fn from(route: Route) -> Self {
+        ViewBuilder::from(route).into()
+    }
+}
+
+impl From<Route> for ViewBuilder<HtmlElement> {
+    fn from(route: Route) -> Self {
+        match route {
+            Route::Home => routes::home(),
+            Route::NotFound => routes::not_found(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Out {
+    Render(Route),
+    RenderClicks(i32),
+}
+
+#[derive(Debug)]
+pub struct App {
+    click_count: i32,
+    current_route: Route,
+}
+
+impl App {
+    pub fn new() -> Self {
+        App {
+            click_count: 0,
+            current_route: Route::Home,
+        }
+    }
+}
+
+impl Component for App {
+    type ModelMsg = Route;
+    type ViewMsg = Out;
+    type DomNode = HtmlElement;
+
+    fn update(&mut self, msg: &Route, tx_view: &Transmitter<Out>, _sub: &Subscriber<Route>) {
+        if self.current_route != *msg {
+            self.current_route = msg.clone();
+            tx_view.send(&Out::Render(self.current_route));
+        }
+        self.click_count += 1;
+        tx_view.send(&Out::RenderClicks(self.click_count));
+    }
+
+    #[allow(unused_braces)]
+    fn view(&self, tx: &Transmitter<Route>, rx: &Receiver<Out>) -> ViewBuilder<HtmlElement> {
+        let rx_text = rx.branch_filter_map(|msg| match msg {
+            Out::RenderClicks(count) if count == &1 => Some(format!("{} time", count)),
+            Out::RenderClicks(count) => Some(format!("{} times", count)),
+            _ => None,
+        });
+        let rx_main = rx.branch_filter_map(|msg| match msg {
+            Out::Render(route) => Some(View::<HtmlElement>::from(*route)),
+            _ => None,
+        });
+        let mut contents = ViewBuilder::from(self.current_route);
+        contents.replaces = vec![rx_main];
+        builder! {
+            <div class="root">
+                <nav>
+                    <button on:click=tx.contra_map(|_| Route::Home)>
+                        "Home"
+                    </button>
+                    <button on:click=tx.contra_map(|_| Route::NotFound)>
+                        "Not Found"
+                    </button>
+                </nav>
+                <p>{("0 times", rx_text)}</p>
+                {contents}
+            </div>
+        }
+    }
+}

--- a/examples/multipage/src/lib.rs
+++ b/examples/multipage/src/lib.rs
@@ -1,0 +1,40 @@
+mod app;
+mod routes;
+
+use log::{trace, Level};
+use mogwai::prelude::*;
+use std::panic;
+use wasm_bindgen::prelude::*;
+
+// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
+// allocator.
+#[cfg(feature = "wee_alloc")]
+#[global_allocator]
+static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+
+#[wasm_bindgen(start)]
+pub fn main() -> Result<(), JsValue> {
+    panic::set_hook(Box::new(console_error_panic_hook::hook));
+    console_log::init_with_level(Level::Trace).expect("could not init console_log");
+
+    if cfg!(debug_assertions) {
+        trace!("Hello from debug mogwai-multipage");
+    } else {
+        trace!("Hello from release mogwai-multipage");
+    }
+
+    // Create our app's view by hydrating a gizmo from an initial state
+    let app: Gizmo<app::App> = Gizmo::new(app::App::new());
+
+    // Hand the app's view ownership to the window so it never
+    // goes out of scope
+    app.run()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/examples/multipage/src/lib.rs
+++ b/examples/multipage/src/lib.rs
@@ -28,7 +28,7 @@ pub fn main() -> Result<(), JsValue> {
 
     // Hand the app's view ownership to the window so it never
     // goes out of scope
-    app.run()
+    View::from(app).run()
 }
 
 #[cfg(test)]

--- a/examples/multipage/src/routes/mod.rs
+++ b/examples/multipage/src/routes/mod.rs
@@ -1,0 +1,59 @@
+use mogwai::prelude::*;
+
+/// Defines a button that changes its text every time it is clicked.
+/// Once built, the button will also transmit clicks into the given transmitter.
+#[allow(unused_braces)]
+fn new_button_view(tx_click: Transmitter<Event>) -> ViewBuilder<HtmlElement> {
+    // Create a receiver for our button to get its text from.
+    let rx_text = Receiver::<String>::new();
+
+    // Create the button that gets its text from our receiver.
+    //
+    // The button text will start out as "Click me" and then change to whatever
+    // comes in on the receiver.
+    let button = builder! {
+        // The button has a style and transmits its clicks
+        <button style="cursor: pointer;" on:click=tx_click.clone()>
+            // The text starts with "Click me" and receives updates
+            {("Click me", rx_text.branch())}
+        </button>
+    };
+
+    // Now that the routing is done, we can define how the signal changes from
+    // transmitter to receiver over each occurance.
+    // We do this by wiring the two together, along with some internal state in the
+    // form of a fold function.
+    tx_click.wire_fold(
+        &rx_text,
+        true, // our initial folding state
+        |is_red, _| {
+            let out = if *is_red {
+                "Turn me blue".into()
+            } else {
+                "Turn me red".into()
+            };
+
+            *is_red = !*is_red;
+            out
+        },
+    );
+
+    button
+}
+
+#[allow(unused_braces)]
+pub fn home() -> ViewBuilder<HtmlElement> {
+    // Create a transmitter to send button clicks into.
+    let tx_click = Transmitter::new();
+    builder! {
+        <main>
+            {new_button_view(tx_click)}
+        </main>
+    }
+}
+
+pub fn not_found() -> ViewBuilder<HtmlElement> {
+    builder! {
+        <h1>"Not Found"</h1>
+    }
+}

--- a/examples/sandbox/Cargo.toml
+++ b/examples/sandbox/Cargo.toml
@@ -12,10 +12,11 @@ edition = "2018"
 [dependencies]
 console_log = "^0.1"
 console_error_panic_hook = "^0.1"
-wasm-bindgen = "^0.2"
 futures = "^0.3"
-wasm-bindgen-futures = "^0.4"
 log = "^0.4"
+mogwai-hydrator = { path = "../../crates/mogwai-hydrator", version = "^0.1" }
+wasm-bindgen = "^0.2"
+wasm-bindgen-futures = "^0.4"
 
 [dependencies.mogwai]
 path = "../../mogwai"

--- a/examples/sandbox/Cargo.toml
+++ b/examples/sandbox/Cargo.toml
@@ -10,18 +10,18 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-console_log = "0.1.2"
-console_error_panic_hook = "0.1.6"
-wasm-bindgen = "0.2"
-futures = "0.3"
-wasm-bindgen-futures = "0.4"
-log = "0.4"
+console_log = "^0.1"
+console_error_panic_hook = "^0.1"
+wasm-bindgen = "^0.2"
+futures = "^0.3"
+wasm-bindgen-futures = "^0.4"
+log = "^0.4"
 
 [dependencies.mogwai]
 path = "../../mogwai"
 
 [dependencies.web-sys]
-version = "0.3.31"
+version = "^0.3"
 features = [
   "Node",
   "NodeList",

--- a/examples/sandbox/src/lib.rs
+++ b/examples/sandbox/src/lib.rs
@@ -4,6 +4,7 @@ mod elm_button;
 
 use log::Level;
 use mogwai::prelude::*;
+use mogwai_hydrator::Hydrator;
 use std::panic;
 use wasm_bindgen::prelude::*;
 use web_sys::{Request, RequestInit, RequestMode, Response};
@@ -244,7 +245,7 @@ pub fn main() -> Result<(), JsValue> {
                 <p class="my_p">{("blah", rx)}</p>
             </div>
         };
-        let hydrator = HydrateView::from(builder);
+        let hydrator = Hydrator::from(builder);
         let view = View::try_from(hydrator).unwrap();
         view.forget()
             .unwrap_throw();

--- a/examples/sandbox/src/lib.rs
+++ b/examples/sandbox/src/lib.rs
@@ -244,11 +244,10 @@ pub fn main() -> Result<(), JsValue> {
                 <p class="my_p">{("blah", rx)}</p>
             </div>
         };
-        builder
-            .hydrate_view()
-            .unwrap()
-            .forget()
-            .unwrap_throw()
+        let hydrator = HydrateView::from(builder);
+        let view = View::try_from(hydrator).unwrap();
+        view.forget()
+            .unwrap_throw();
     };
 
     tx.send(&());

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -13,8 +13,8 @@ default = ["console_error_panic_hook"]
 [dependencies]
 console_log = "^0.1"
 log = "^0.4"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { version = "^1.0", features = ["derive"] }
+serde_json = "^1.0"
 wasm-bindgen = "^0.2"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -44,4 +44,4 @@ features = [
 ]
 
 [dev-dependencies]
-wasm-bindgen-test = "^0.2"
+wasm-bindgen-test = "0.3.0"

--- a/examples/todomvc/index.html
+++ b/examples/todomvc/index.html
@@ -6,41 +6,6 @@
         <link rel="stylesheet" href="todo.css">
     </head>
     <body>
-        <section id="todo_main" class="todoapp">
-            <header class="header">
-                <h1>todos</h1>
-                <input class="new-todo" id="new-todo" placeholder="What needs to be done?" />
-            </header>
-            <section class="main" style="display: none;">
-                <input id="toggle-all" type="checkbox" class="toggle-all" /git add -A
-                       git commit -am "WIP"
-                       git push keybase kinda_iso
-                >
-                <label for="toggle-all">Mark all as complete</label>
-                <ul class="todo-list" style="display: none;"></ul>
-            </section>
-            <footer class="footer" style="display: none;">
-                <span class="todo-count"><strong>0 items left</strong></span>
-                <ul class="filters">
-                    <li><a href="#/">All</a></li>
-                    <li><a href="#/active">Active</a></li>
-                    <li><a href="#/completed">Completed</a></li>
-                </ul>
-                <button class="clear-completed" style="display: none;">Clear completed</button>
-            </footer>
-        </section>
-        <footer id="todo_footer" class="info">
-        <p>Double click to edit a todo</p>
-        <p>
-            Written by
-            <a href="https://github.com/schell">Schell Scivally</a>
-        </p>
-        <p>
-            Part of
-            <a href="http://todomvc.com">TodoMVC</a>
-        </p>
-        </footer>
-
         <script type=module>
         import init from './pkg/todomvc.js';
             window.addEventListener('load', async () => {

--- a/examples/todomvc/src/app.rs
+++ b/examples/todomvc/src/app.rs
@@ -265,7 +265,7 @@ impl Component for App {
             _ => None,
         });
 
-        let hydrated_view = hydrate! {
+        builder! {
             <section id="todo_main" class="todoapp">
                 <header class="header">
                     <h1>"todos"</h1>
@@ -353,8 +353,6 @@ impl Component for App {
                     </button>
                 </footer>
             </section>
-        };
-
-        ViewBuilder::from(hydrated_view)
+        }
     }
 }

--- a/examples/todomvc/src/app.rs
+++ b/examples/todomvc/src/app.rs
@@ -40,7 +40,7 @@ pub enum Out {
 
 pub struct App {
     next_index: usize,
-    todos: Vec<Gremlin<Todo>>,
+    todos: Vec<Gizmo<Todo>>,
     todo_input: Option<HtmlInputElement>,
     todo_toggle_input: Option<HtmlInputElement>,
     has_completed: bool,
@@ -140,9 +140,9 @@ impl Component for App {
         match msg {
             In::NewTodo(name, complete) => {
                 let index = self.next_index;
-                // Turn the new todo into a gizmo and split that into a view and the remaining
-                // component (a "Gremlin").
-                let (view, component) = Gizmo::new(Todo::new(index, name.to_string())).split_view();
+                // Turn the new todo into a gizmo, wire it up and spawn a viewbuilder, turning it into a view
+                // and sending to patch our todo list
+                let component = Gizmo::new(Todo::new(index, name.to_string()));
                 // Subscribe to some of its view messages
                 sub.subscribe_filter_map(&component.recv, move |todo_out_msg| match todo_out_msg {
                     TodoOut::UpdateEditComplete(_, is_complete) => {
@@ -157,7 +157,7 @@ impl Component for App {
 
                 // Add the gizmo's view to the app's view
                 tx_view.send(&Out::PatchTodos(Patch::PushBack {
-                    value: view,
+                    value: View::from(component.view_builder()),
                 }));
 
                 // Store the gizmo so we can update it later

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -41,11 +41,12 @@ pub fn main() -> Result<(), JsValue> {
         .into_iter()
         .for_each(|msg| msgs.push(msg));
 
-    // Create our app's view by hydrating a gizmo from an initial state
-    let app: Gizmo<App> = match Gizmo::hydrate(App::new()) {
-        Err(err) => panic!("{}", err),
-        Ok(app) => app,
-    };
+    //// Create our app's view by hydrating a gizmo from an initial state
+    //let app: Gizmo<App> = match Gizmo::hydrate(App::new()) {
+    //    Err(err) => panic!("{}", err),
+    //    Ok(app) => app,
+    //};
+    let app: Gizmo<App> = Gizmo::from(App::new());
 
     // Send our gizmo all the initial messages it needs to populate
     // the stored todos.

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -23,8 +23,7 @@ fn fresh_app(msgs: Vec<In>) -> Result<(), JsValue> {
         app.send(&msg);
     });
 
-    let Gizmo { view, .. } = app;
-    view.run()
+    View::from(app).run()
 }
 
 

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -20,11 +20,11 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 fn fresh_app(msgs: Vec<In>) -> Result<(), JsValue> {
     let app: Gizmo<App> = Gizmo::from(App::new());
     msgs.into_iter().for_each(|msg| {
-        app.update(&msg);
+        app.send(&msg);
     });
 
-    let Gizmo { view: app_view, .. } = app;
-    app_view.run()
+    let Gizmo { view, .. } = app;
+    view.run()
 }
 
 

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -17,6 +17,17 @@ use app::{App, In};
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 
+fn fresh_app(msgs: Vec<In>) -> Result<(), JsValue> {
+    let app: Gizmo<App> = Gizmo::from(App::new());
+    msgs.into_iter().for_each(|msg| {
+        app.update(&msg);
+    });
+
+    let Gizmo { view: app_view, .. } = app;
+    app_view.run()
+}
+
+
 #[wasm_bindgen(start)]
 pub fn main() -> Result<(), JsValue> {
     panic::set_hook(Box::new(console_error_panic_hook::hook));
@@ -41,26 +52,5 @@ pub fn main() -> Result<(), JsValue> {
         .into_iter()
         .for_each(|msg| msgs.push(msg));
 
-    //// Create our app's view by hydrating a gizmo from an initial state
-    //let app: Gizmo<App> = match Gizmo::hydrate(App::new()) {
-    //    Err(err) => panic!("{}", err),
-    //    Ok(app) => app,
-    //};
-    let app: Gizmo<App> = Gizmo::from(App::new());
-
-    // Send our gizmo all the initial messages it needs to populate
-    // the stored todos.
-    msgs.into_iter().for_each(|msg| {
-        // notice how this doesn't mutate the app gizmo -
-        // under the hood we're simply queueing these messages
-        app.update(&msg);
-    });
-
-    // Unravel the gizmo because all we need is the view -
-    // we can disregard the message terminals and the shared state
-    // (the view already has clones of these things).
-    let Gizmo { view: app_view, .. } = app;
-    // Hand the app's view ownership to the window so it never
-    // goes out of scope
-    app_view.forget()
+    fresh_app(msgs)
 }

--- a/mogwai/Cargo.toml
+++ b/mogwai/Cargo.toml
@@ -40,7 +40,7 @@ features = [
 
 [dev-dependencies]
 doc-comment = "^0.3"
-wasm-bindgen-test = "0.3.0"
+wasm-bindgen-test = "0.3.17"
 wasm-bindgen-futures = "^0.4"
 
 [dev-dependencies.web-sys]

--- a/mogwai/Cargo.toml
+++ b/mogwai/Cargo.toml
@@ -39,6 +39,7 @@ features = [
 
 [dev-dependencies]
 doc-comment = "^0.3"
+mogwai-hydrator = { path = "../crates/mogwai-hydrator", version = "^0.1" }
 wasm-bindgen-test = "0.3.17"
 wasm-bindgen-futures = "^0.4"
 

--- a/mogwai/Cargo.toml
+++ b/mogwai/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["gui", "wasm", "web-programming"]
 
 [dependencies]
 futures = "^0.3"
-js-sys = "^0.3"
+js-sys = "0.3.44"
 mogwai-html-macro = { path = "../crates/mogwai-html-macro", version = "^0.2" }
 snafu = "^0.6"
 wasm-bindgen = "^0.2"
@@ -40,7 +40,7 @@ features = [
 
 [dev-dependencies]
 doc-comment = "^0.3"
-wasm-bindgen-test = "^0.3"
+wasm-bindgen-test = "0.3.0"
 wasm-bindgen-futures = "^0.4"
 
 [dev-dependencies.web-sys]

--- a/mogwai/Cargo.toml
+++ b/mogwai/Cargo.toml
@@ -18,6 +18,9 @@ mogwai-html-macro = { path = "../crates/mogwai-html-macro", version = "^0.2" }
 wasm-bindgen = "^0.2"
 wasm-bindgen-futures = "^0.4"
 
+console_log = "^0.1"
+log = "^0.4"
+
 [dependencies.web-sys]
 version = "^0.3"
 features = [
@@ -33,6 +36,7 @@ features = [
   "MessagePort",
   "Node",
   "NodeList",
+  "Performance",
   "Text",
   "Window"
 ]

--- a/mogwai/Cargo.toml
+++ b/mogwai/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["gui", "wasm", "web-programming"]
 futures = "^0.3"
 js-sys = "0.3.44"
 mogwai-html-macro = { path = "../crates/mogwai-html-macro", version = "^0.2" }
-snafu = "^0.6"
 wasm-bindgen = "^0.2"
 wasm-bindgen-futures = "^0.4"
 

--- a/mogwai/src/an_introduction.rs
+++ b/mogwai/src/an_introduction.rs
@@ -1,3 +1,4 @@
+#![allow(unused_braces)]
 //! An introduction to the minimal, obvious, graphical web application interface.
 //!
 //! # Welcome!
@@ -121,13 +122,14 @@ use crate as mogwai;
 
 struct Unit {}
 
+
 impl Component for Unit {
     type ModelMsg = ();
     type ViewMsg = ();
     type DomNode = HtmlElement;
 
-    fn view(&self, _: Transmitter<()>, _: Receiver<()>) -> View<HtmlElement> {
-        view! {
+    fn view(&self, _: &Transmitter<()>, _: &Receiver<()>) -> ViewBuilder<HtmlElement> {
+        builder! {
             <a href="/#">"Hello"</a>
         }
     }

--- a/mogwai/src/component.rs
+++ b/mogwai/src/component.rs
@@ -81,9 +81,8 @@
 //!
 //!
 //! pub fn main() -> Result<(), JsValue> {
-//!     Gizmo::from(
-//!         App{ num_clicks: 0 }
-//!     ).run()
+//!     let app = Gizmo::from(App{ num_clicks: 0 });
+//!     View::from(app).run()
 //! }
 //! ```
 //!

--- a/mogwai/src/gizmo.rs
+++ b/mogwai/src/gizmo.rs
@@ -1,10 +1,10 @@
-use std::{cell::RefCell, rc::Rc, convert::TryFrom};
+use std::{cell::RefCell, rc::Rc};
 pub use wasm_bindgen::{JsCast, JsValue, UnwrapThrowExt};
 use web_sys::Node;
 pub use web_sys::{Element, Event, EventTarget, HtmlInputElement};
 
 use crate::{
-    prelude::{txrx, Component, HydrateView, Receiver, Subscriber, Transmitter, View, ViewBuilder},
+    prelude::{txrx, Component, Receiver, Subscriber, Transmitter, View, ViewBuilder},
     utils,
 };
 
@@ -66,18 +66,6 @@ where
         let view = View::from(view_builder);
 
         Gizmo::from_parts(init, tx_in, rx_out, view)
-    }
-
-    /// Hydrates a new [`Gizmo`] from a stateful [`Component`].
-    /// If the view cannot be hydrated an error is returned.
-    pub fn hydrate(init: T) -> Result<Gizmo<T>, crate::view::hydration::Error> {
-        let tx_in = Transmitter::new();
-        let rx_out = Receiver::new();
-        let view_builder = init.view(&tx_in, &rx_out);
-        let hydrated = HydrateView::from(view_builder);
-        let view = View::try_from(hydrated)?;
-
-        Ok(Gizmo::from_parts(init, tx_in, rx_out, view))
     }
 
     /// A reference to the browser's DomNode.

--- a/mogwai/src/lib.rs
+++ b/mogwai/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! ## Learn more
 //! If you're new to Mogwai, check out the [introduction](an_introduction) module.
-//pub mod an_introduction;
+pub mod an_introduction;
 pub mod component;
 pub mod gizmo;
 pub mod prelude;

--- a/mogwai/src/lib.rs
+++ b/mogwai/src/lib.rs
@@ -19,5 +19,5 @@ pub mod txrx;
 pub mod utils;
 pub mod view;
 
-//#[cfg(doctest)]
-//doc_comment::doctest!("../../README.md");
+#[cfg(doctest)]
+doc_comment::doctest!("../../README.md");

--- a/mogwai/src/lib.rs
+++ b/mogwai/src/lib.rs
@@ -13,6 +13,7 @@ pub mod an_introduction;
 pub mod component;
 pub mod gizmo;
 pub mod prelude;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod ssr;
 pub mod txrx;
 pub mod utils;

--- a/mogwai/src/prelude.rs
+++ b/mogwai/src/prelude.rs
@@ -7,7 +7,7 @@ pub use super::{
         txrx_fold_shared, txrx_map, wrap_future, Receiver, Transmitter,
     },
     utils::*,
-    view::{builder::*, dom::*, hydration::*, interface::*, *},
+    view::{builder::*, dom::*, interface::*, *},
     *,
 };
 pub use std::convert::TryFrom;

--- a/mogwai/src/txrx.rs
+++ b/mogwai/src/txrx.rs
@@ -258,8 +258,6 @@
 //! * [Transmitter::wire_fold_shared]
 //! * [Transmitter::wire_map]
 //!
-//! Note that they all mutate the [Transmitter] they are called on.
-//!
 //! Conversely, if you would like to forward messages from a receiver into a
 //! transmitter of a different type you can "forward" messages from the receiver
 //! to the transmitter:
@@ -397,6 +395,7 @@ use std::{
     task::{Context, Poll, Waker},
 };
 use wasm_bindgen_futures::spawn_local;
+
 
 pub type RecvFuture<A> = Pin<Box<dyn Future<Output = Option<A>>>>;
 
@@ -754,7 +753,7 @@ impl<A> Receiver<A> {
     /// Set the response this receiver has to messages. Upon receiving a message
     /// the response will run immediately.
     ///
-    /// Folds mutably over a shared Rc<RefCell<T>>.
+    /// Folds mutably over a Rc<RefCell<T>>.
     pub fn respond_shared<T: 'static, F>(self, val: Rc<RefCell<T>>, f: F)
     where
         F: Fn(&mut T, &A) + 'static,
@@ -1046,8 +1045,8 @@ impl<A> Receiver<A> {
     where
         A: Clone + 'static,
     {
-        let var = Rc::new(RefCell::new(None));
-        let var2 = var.clone();
+        let var: Rc<RefCell<Option<A>>> = Rc::new(RefCell::new(None));
+        let var2: Rc<RefCell<Option<A>>> = var.clone();
         let waker: Rc<RefCell<Option<Waker>>> = Rc::new(RefCell::new(None));
         let waker2 = waker.clone();
         self.branch().respond(move |msg| {

--- a/mogwai/src/txrx.rs
+++ b/mogwai/src/txrx.rs
@@ -718,20 +718,9 @@ pub struct Receiver<A> {
 }
 
 
-/// Clone a receiver.
-///
-/// # Warning!
-/// Be careful with this function. Because of magic, calling
-/// [Receiver::respond] on a clone of a receiver sets the responder for both of
-/// those receivers. **Under the hood they are the same responder**. This is why
-/// [Receiver] has no [Clone] trait implementation.
-///
-/// Instead of cloning, if you need a new receiver that receives from the same
-/// transmitter you should use [Receiver::branch], which comes in many flavors.
-pub(crate) fn hand_clone<A>(rx: &Receiver<A>) -> Receiver<A> {
-    Receiver {
-        k: rx.k,
-        responders: rx.responders.clone(),
+impl<A> Clone for Receiver<A> {
+    fn clone(&self) -> Self {
+        self.responders.clone().recv_from()
     }
 }
 

--- a/mogwai/src/utils.rs
+++ b/mogwai/src/utils.rs
@@ -5,7 +5,6 @@ use std::{
     pin::Pin,
     rc::Rc,
     task::{Context, Poll, Waker},
-    time::{Duration, Instant},
 };
 use wasm_bindgen::{closure::Closure, JsCast, JsValue, UnwrapThrowExt};
 use web_sys;

--- a/mogwai/src/utils.rs
+++ b/mogwai/src/utils.rs
@@ -1,7 +1,11 @@
 use std::{
+    future::Future,
     cell::{Cell, RefCell},
     collections::VecDeque,
+    pin::Pin,
     rc::Rc,
+    task::{Context, Poll, Waker},
+    time::{Duration, Instant},
 };
 use wasm_bindgen::{closure::Closure, JsCast, JsValue, UnwrapThrowExt};
 use web_sys;
@@ -146,5 +150,59 @@ pub fn add_event(
 ) -> MogwaiCallback {
     MogwaiCallback {
         callback: Rc::new(Box::new(|_| {})),
+    }
+}
+
+
+struct WaitFuture {
+    start: f64,
+    millis: f64,
+    waker: Rc<RefCell<Option<Waker>>>,
+}
+
+
+impl Future for WaitFuture {
+    type Output = f64;
+
+    fn poll(self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Self::Output> {
+        let future: &mut WaitFuture = self.get_mut();
+        let now =
+            window()
+            .performance()
+            .expect("no performance object")
+            .now();
+        let elapsed = now - future.start;
+        if elapsed >= future.millis {
+            Poll::Ready(elapsed)
+        } else {
+            *future.waker.borrow_mut() = Some(ctx.waker().clone());
+            Poll::Pending
+        }
+    }
+}
+
+
+/// Wait approximately the given number of milliseconds.
+/// Returns a [`Future`] that yields the actual number of milliseconds waited.
+pub fn wait_approximately(millis: f64) -> impl Future<Output = f64> {
+    let waker: Rc<RefCell<Option<Waker>>> = Rc::new(RefCell::new(None));
+    let waker2 = waker.clone();
+    let start =
+        window()
+        .performance()
+        .expect("no performance object")
+        .now();
+    timeout(millis as i32, move || {
+        waker2
+            .borrow_mut()
+            .take()
+            .into_iter()
+            .for_each(|waker| waker.wake());
+        false
+    });
+    WaitFuture {
+        start,
+        waker,
+        millis
     }
 }

--- a/mogwai/src/view.rs
+++ b/mogwai/src/view.rs
@@ -39,9 +39,9 @@ impl<T: Clone> Clone for Effect<T> {
 }
 
 
-impl<T> Effect<T> {
-    pub fn into_some(self) -> (Option<T>, Option<Receiver<T>>) {
-        match self {
+impl<T> From<Effect<T>> for (Option<T>, Option<Receiver<T>>) {
+    fn from(eff: Effect<T>) -> Self {
+        match eff {
             Effect::OnceNow { now } => (Some(now), None),
             Effect::ManyLater { later } => (None, Some(later)),
             Effect::OnceNowAndManyLater { now, later } => (Some(now), Some(later)),
@@ -93,3 +93,10 @@ impl From<(&str, Receiver<String>)> for Effect<String> {
         }
     }
 }
+
+
+/// Marker trait that means JsCast + Clone + + 'static.
+pub trait IsDomNode: JsCast + Clone + 'static {}
+
+
+impl<T> IsDomNode for T where T: JsCast + Clone + 'static {}

--- a/mogwai/src/view.rs
+++ b/mogwai/src/view.rs
@@ -1,4 +1,5 @@
 //! Views
+use std::{cell::RefCell, rc::Rc};
 pub use wasm_bindgen::{JsCast, JsValue, UnwrapThrowExt};
 pub use web_sys::{Element, Event, EventTarget, HtmlInputElement};
 
@@ -79,6 +80,14 @@ impl<T> From<Receiver<T>> for Effect<T> {
 
 impl<T> From<(T, Receiver<T>)> for Effect<T> {
     fn from((now, later): (T, Receiver<T>)) -> Effect<T> {
+        Effect::OnceNowAndManyLater { now, later }
+    }
+}
+
+
+impl<T> From<(Option<T>, Receiver<Rc<RefCell<Option<T>>>>)> for Effect<Rc<RefCell<Option<T>>>> {
+    fn from((now, later): (Option<T>, Receiver<Rc<RefCell<Option<T>>>>)) -> Self {
+        let now = Rc::new(RefCell::new(now));
         Effect::OnceNowAndManyLater { now, later }
     }
 }

--- a/mogwai/src/view.rs
+++ b/mogwai/src/view.rs
@@ -6,7 +6,6 @@ use crate::prelude::Receiver;
 
 pub mod builder;
 pub mod dom;
-pub mod hydration;
 pub mod interface;
 
 

--- a/mogwai/src/view/builder.rs
+++ b/mogwai/src/view/builder.rs
@@ -5,64 +5,295 @@
 pub use wasm_bindgen::{JsCast, JsValue, UnwrapThrowExt};
 use web_sys::Node;
 pub use web_sys::{Element, Event, EventTarget, HtmlInputElement, Text};
+use snafu::OptionExt;
 
 use crate::{
-    prelude::{Effect, Error, HydrateView, Receiver, Transmitter, TryFrom, View},
-    view::{interface::*, hydration::ViewOnly},
+    utils,
+    prelude::{Effect, HydrateView, Receiver, Transmitter, View},
+    view::{hydration, interface::*},
 };
 
 
-pub struct ViewBuilder<T: JsCast> {
-    view_fn: Box<dyn FnOnce() -> View<T>>,
-    hydrate_fn: Box<dyn FnOnce() -> HydrateView<T>>,
+enum AttributeCmd {
+    Attrib {
+        name: String,
+        effect: Effect<String>,
+    },
+    Bool {
+        name: String,
+        effect: Effect<bool>,
+    },
 }
 
 
-impl<T: JsCast + 'static> ViewBuilder<T> {
-    pub fn new<VF, HF>(view_fn: VF, hydrate_fn: HF) -> Self
-    where
-        VF: FnOnce() -> View<T> + 'static,
-        HF: FnOnce() -> HydrateView<T> + 'static,
-    {
-        let view_fn = Box::new(view_fn);
-        let hydrate_fn = Box::new(hydrate_fn);
+struct StyleCmd {
+    name: String,
+    effect: Effect<String>,
+}
+
+
+enum EventTargetType {
+    Myself,
+    Window,
+    Document,
+}
+
+
+struct EventTargetCmd {
+    type_is: EventTargetType,
+    name: String,
+    transmitter: Transmitter<Event>,
+}
+
+
+pub struct ViewBuilder<T: JsCast> {
+    element: Option<String>,
+    ns: Option<String>,
+    text: Option<Effect<String>>,
+    attribs: Vec<AttributeCmd>,
+    styles: Vec<StyleCmd>,
+    events: Vec<EventTargetCmd>,
+    posts: Vec<Transmitter<T>>,
+    children: Vec<ViewBuilder<Node>>,
+}
+
+
+impl<T: JsCast> Default for ViewBuilder<T> {
+    fn default() -> Self {
         ViewBuilder {
-            view_fn,
-            hydrate_fn,
+            element: None,
+            ns: None,
+            text: None,
+            attribs: vec![],
+            styles: vec![],
+            events: vec![],
+            posts: vec![],
+            children: vec![],
+        }
+    }
+}
+
+
+impl<T: Clone + JsCast + AsRef<Node> + 'static> ViewBuilder<T> {
+    fn to_node(self) -> ViewBuilder<Node> {
+        ViewBuilder {
+            element: self.element,
+            ns: self.ns,
+            text: self.text,
+            attribs: self.attribs,
+            styles: self.styles,
+            events: self.events,
+            children: self.children,
+            posts: self
+                .posts
+                .into_iter()
+                .map(|tx: Transmitter<T>| -> Transmitter<Node> {
+                    tx.contra_map(|node: &Node| -> T {
+                        let t: &T = node.unchecked_ref();
+                        t.clone()
+                    })
+                })
+                .collect(),
         }
     }
 
-    pub fn append_update<VF, HF>(&mut self, view_fn: VF, hydrate_fn: HF)
-    where
-        VF: FnOnce(View<T>) -> View<T> + 'static,
-        HF: FnOnce(HydrateView<T>) -> HydrateView<T> + 'static,
-    {
-        let f = std::mem::replace(&mut self.view_fn, Box::new(|| panic!()));
-        self.view_fn = Box::new(move || view_fn(f()));
+    //pub fn new<VF, HF>(view_fn: VF, hydrate_fn: HF) -> Self
+    //where
+    //    VF: FnOnce() -> View<T> + 'static,
+    //    HF: FnOnce() -> HydrateView<T> + 'static,
+    //{
+    //    let view_fn = Box::new(view_fn);
+    //    let hydrate_fn = Box::new(hydrate_fn);
+    //    ViewBuilder {
+    //        view_fn,
+    //        hydrate_fn,
+    //    }
+    //}
 
-        let f = std::mem::replace(&mut self.hydrate_fn, Box::new(|| panic!()));
-        self.hydrate_fn = Box::new(move || hydrate_fn(f()));
+    //pub fn append_update<VF, HF>(&mut self, view_fn: VF, hydrate_fn: HF)
+    //where
+    //    VF: FnOnce(View<T>) -> View<T> + 'static,
+    //    HF: FnOnce(HydrateView<T>) -> HydrateView<T> + 'static,
+    //{
+    //    let f = std::mem::replace(&mut self.view_fn, Box::new(|| panic!()));
+    //    self.view_fn = Box::new(move || view_fn(f()));
+
+    //    let f = std::mem::replace(&mut self.hydrate_fn, Box::new(|| panic!()));
+    //    self.hydrate_fn = Box::new(move || hydrate_fn(f()));
+    //}
+}
+
+
+/// [`ViewBuilder`] can be converted into a [`HydrateView`].
+impl<T> From<ViewBuilder<T>> for HydrateView<T>
+where
+    T: JsCast + AsRef<Node> + Clone + 'static,
+{
+    fn from(builder: ViewBuilder<T>) -> HydrateView<T> {
+        let ViewBuilder {
+            element,
+            ns,
+            attribs,
+            styles,
+            events,
+            children,
+            posts,
+            text,
+        } = builder;
+        let mut hview: HydrateView<T> = if let Some(tag) = element {
+            if let Some(ns) = ns {
+                HydrateView::element_ns(&tag, &ns)
+            } else {
+                HydrateView::element(&tag)
+            }
+        } else if let Some(effect) = text {
+            let text = HydrateView::from(effect);
+            text.cast::<T>()
+        } else {
+            panic!("not hydrating an element - impossible!")
+        };
+
+        if events.len() > 0 {
+            hview.append_update(|view: &mut View<T>| {
+                let t:T = {
+                    let t:&T = &view;
+                    t.clone()
+                };
+                let myself = t.dyn_ref::<EventTarget>().with_context(|| hydration::Conversion {
+                    from: std::any::type_name::<T>().to_string(),
+                    to: std::any::type_name::<EventTarget>().to_string(),
+                    node: view.element.as_ref().clone()
+                })?;
+                let window = utils::window();
+                let doc = utils::document();
+                for cmd in events.into_iter() {
+                    match cmd.type_is {
+                        EventTargetType::Myself => view.add_event(myself, &cmd.name, cmd.transmitter),
+                        EventTargetType::Window => view.add_event(&window, &cmd.name, cmd.transmitter),
+                        EventTargetType::Document => view.add_event(&doc, &cmd.name, cmd.transmitter),
+                    }
+                }
+                Ok(())
+            });
+        }
+        if styles.len() > 0 {
+            hview.append_update(|view: &mut View<T>| {
+                for cmd in styles.into_iter() {
+                    view.add_style(&cmd.name, cmd.effect);
+                }
+                Ok(())
+            });
+        }
+
+        if attribs.len() > 0 {
+            hview.append_update(|view: &mut View<T>| {
+                for cmd in attribs.into_iter() {
+                    match cmd {
+                        AttributeCmd::Attrib { name, effect } => {
+                            view.add_attribute(&name, effect);
+                        }
+                        AttributeCmd::Bool { name, effect } => {
+                            view.add_boolean_attribute(&name, effect);
+                        }
+                    }
+                }
+                Ok(())
+            });
+        }
+
+        for tx in posts.into_iter() {
+            hview.post_build(tx);
+        }
+
+        for child in children.into_iter() {
+            let child = HydrateView::from(child);
+            hview.with(child);
+        }
+
+        hview
     }
+}
 
-    /// Convert this builder into a fresh [`View`].
-    pub fn fresh_view(self) -> View<T> {
-        (self.view_fn)()
-    }
 
-    /// Attempt to convert this builder into a [`View`] hydrated from
-    /// the existing DOM.
-    pub fn hydrate_view(self) -> Result<View<T>, Error> {
-        let hydrate = (self.hydrate_fn)();
-        let val = View::try_from(hydrate)?;
-        Ok(val)
-    }
+/// [`ViewBuilder`] can be converted into a fresh [`View`].
+impl<T> From<ViewBuilder<T>> for View<T>
+where
+    T: JsCast + Clone + AsRef<Node> + 'static,
+{
+    fn from(builder: ViewBuilder<T>) -> View<T> {
+        let ViewBuilder {
+            element,
+            ns,
+            attribs,
+            styles,
+            events,
+            children,
+            posts,
+            text,
+        } = builder;
+        let mut view: View<T> = match element {
+            Some(tag) => match ns {
+                Some(ns) => View::element_ns(&tag, &ns),
+                _ => View::element(&tag),
+            },
+            _ => match text {
+                Some(effect) => {
+                    let text = View::from(effect);
+                    text.try_cast::<T>()
+                        .unwrap_or_else(|_| panic!("not text - impossible!"))
+                }
+                _ => panic!("not an element - impossible!"),
+            },
+        };
 
-    /// Attempt to convert this build into a [`View`] hydrated from
-    /// the existing DOM - if that fails, create a fresh view.
-    pub fn hydrate_or_else_fresh_view(self) -> View<T> {
-        let hydrate = self.hydrate_fn;
-        let fresh = self.view_fn;
-        View::try_from(hydrate()).unwrap_or_else(|_| fresh())
+        if events.len() > 0 && view.has_type::<EventTarget>() {
+            let mut ev_view: View<EventTarget> = View::default();
+            view.swap(&mut ev_view);
+            for cmd in events.into_iter() {
+                match cmd.type_is {
+                    EventTargetType::Myself => ev_view.on(&cmd.name, cmd.transmitter),
+                    EventTargetType::Window => ev_view.window_on(&cmd.name, cmd.transmitter),
+                    EventTargetType::Document => ev_view.document_on(&cmd.name, cmd.transmitter)
+                }
+            }
+            view.swap(&mut ev_view);
+        }
+
+        if styles.len() > 0 && view.has_type::<HtmlElement>() {
+            let mut style_view: View<HtmlElement> = View::default();
+            view.swap(&mut style_view);
+            for cmd in styles.into_iter() {
+                style_view.style(&cmd.name, cmd.effect);
+            }
+            view.swap(&mut style_view);
+        }
+
+        if attribs.len() > 0 && view.has_type::<Element>() {
+            let mut att_view: View<Element> = View::default();
+            view.swap(&mut att_view);
+            for cmd in attribs.into_iter() {
+                match cmd {
+                    AttributeCmd::Attrib { name, effect } => {
+                        att_view.attribute(&name, effect);
+                    }
+                    AttributeCmd::Bool { name, effect } => {
+                        att_view.boolean_attribute(&name, effect);
+                    }
+                }
+            }
+            view.swap(&mut att_view);
+        }
+
+        for tx in posts.into_iter() {
+            view.post_build(tx);
+        }
+
+        for child in children.into_iter() {
+            let child = View::from(child);
+            view.with(child);
+        }
+
+        view
     }
 }
 
@@ -74,9 +305,10 @@ impl<T: JsCast + 'static> ViewBuilder<T> {
 
 
 impl From<Effect<String>> for ViewBuilder<Text> {
-    fn from(eff: Effect<String>) -> Self {
-        let view_eff = eff.clone();
-        ViewBuilder::new(|| View::from(view_eff), || HydrateView::from(eff))
+    fn from(effect: Effect<String>) -> Self {
+        let mut builder = ViewBuilder::default();
+        builder.text = Some(effect);
+        builder
     }
 }
 
@@ -133,22 +365,8 @@ impl From<&str> for ViewBuilder<Text> {
 
 impl From<String> for ViewBuilder<Text> {
     fn from(text: String) -> Self {
-        let vtext = text.clone();
-        ViewBuilder::new(|| View::from(vtext), || HydrateView::from(text))
-    }
-}
-
-
-impl<T: JsCast + 'static> From<View<T>> for ViewBuilder<T> {
-    fn from(view: View<T>) -> Self {
-        ViewBuilder::new(|| view, || HydrateView::from_create_fn(|| ViewOnly.fail()))
-    }
-}
-
-
-impl<T: JsCast + 'static> From<HydrateView<T>> for ViewBuilder<T> {
-    fn from(hview: HydrateView<T>) -> Self {
-        ViewBuilder::new(|| panic!("could not create a fresh view - hydrate only"), || hview)
+        let effect = Effect::OnceNow { now: text };
+        ViewBuilder::from(effect)
     }
 }
 
@@ -158,23 +376,16 @@ impl<T: JsCast + 'static> From<HydrateView<T>> for ViewBuilder<T> {
 
 impl<T: JsCast + AsRef<Node> + 'static> ElementView for ViewBuilder<T> {
     fn element(tag: &str) -> Self {
-        let vtag = tag.to_owned();
-        let htag = tag.to_owned();
-        ViewBuilder::new(
-            move || View::element(&vtag),
-            move || HydrateView::element(&htag),
-        )
+        let mut builder = ViewBuilder::default();
+        builder.element = Some(tag.into());
+        builder
     }
 
     fn element_ns(tag: &str, ns: &str) -> Self {
-        let vtag = tag.to_owned();
-        let vns = ns.to_owned();
-        let htag = tag.to_owned();
-        let hns = ns.to_owned();
-        ViewBuilder::new(
-            move || View::element_ns(&vtag, &vns),
-            move || HydrateView::element_ns(&htag, &hns),
-        )
+        let mut builder = ViewBuilder::default();
+        builder.element = Some(tag.into());
+        builder.ns = Some(ns.into());
+        builder
     }
 }
 
@@ -183,29 +394,20 @@ impl<T: JsCast + AsRef<Node> + 'static> ElementView for ViewBuilder<T> {
 
 
 impl<T: JsCast + AsRef<Node> + AsRef<Element> + 'static> AttributeView for ViewBuilder<T> {
-    fn attribute<E: Into<Effect<String>>>(mut self, name: &str, eff: E) -> Self {
-        let vname = name.to_owned();
-        let veff = eff.into();
-        let hname = name.to_owned();
-        let heff = veff.clone();
-        self.append_update(
-            move |v| v.attribute(&vname, veff),
-            move |v| v.attribute(&hname, heff),
-        );
-        self
+    fn attribute<E: Into<Effect<String>>>(&mut self, name: &str, eff: E) {
+        let effect = eff.into();
+        self.attribs.push(AttributeCmd::Attrib {
+            name: name.to_string(),
+            effect,
+        });
     }
 
-
-    fn boolean_attribute<E: Into<Effect<bool>>>(mut self, name: &str, eff: E) -> Self {
-        let vname = name.to_owned();
-        let veff = eff.into();
-        let hname = name.to_owned();
-        let heff = veff.clone();
-        self.append_update(
-            move |v| v.boolean_attribute(&vname, veff),
-            move |v| v.boolean_attribute(&hname, heff),
-        );
-        self
+    fn boolean_attribute<E: Into<Effect<bool>>>(&mut self, name: &str, eff: E) {
+        let effect = eff.into();
+        self.attribs.push(AttributeCmd::Bool {
+            name: name.to_string(),
+            effect,
+        });
     }
 }
 
@@ -214,16 +416,12 @@ impl<T: JsCast + AsRef<Node> + AsRef<Element> + 'static> AttributeView for ViewB
 
 
 impl<T: JsCast + AsRef<HtmlElement> + 'static> StyleView for ViewBuilder<T> {
-    fn style<E: Into<Effect<String>>>(mut self, name: &str, eff: E) -> Self {
-        let vname = name.to_owned();
-        let veff = eff.into();
-        let hname = name.to_owned();
-        let heff = veff.clone();
-        self.append_update(
-            move |v| v.style(&vname, veff),
-            move |v| v.style(&hname, heff),
-        );
-        self
+    fn style<E: Into<Effect<String>>>(&mut self, name: &str, eff: E) {
+        let effect = eff.into();
+        self.styles.push(StyleCmd {
+            name: name.to_string(),
+            effect,
+        });
     }
 }
 
@@ -232,34 +430,28 @@ impl<T: JsCast + AsRef<HtmlElement> + 'static> StyleView for ViewBuilder<T> {
 
 
 impl<T: JsCast + AsRef<EventTarget> + 'static> EventTargetView for ViewBuilder<T> {
-    fn on(mut self, ev_name: &str, tx: Transmitter<Event>) -> Self {
-        let vev_name = ev_name.to_owned();
-        let vtx = tx.clone();
-        let hev_name = vev_name.clone();
-        self.append_update(move |v| v.on(&vev_name, vtx), move |v| v.on(&hev_name, tx));
-        self
+    fn on(&mut self, ev_name: &str, tx: Transmitter<Event>) {
+        self.events.push(EventTargetCmd {
+            type_is: EventTargetType::Myself,
+            name: ev_name.to_string(),
+            transmitter: tx,
+        });
     }
 
-    fn window_on(mut self, ev_name: &str, tx: Transmitter<Event>) -> Self {
-        let vev_name = ev_name.to_owned();
-        let vtx = tx.clone();
-        let hev_name = vev_name.clone();
-        self.append_update(
-            move |v| v.window_on(&vev_name, vtx),
-            move |v| v.window_on(&hev_name, tx),
-        );
-        self
+    fn window_on(&mut self, ev_name: &str, tx: Transmitter<Event>) {
+        self.events.push(EventTargetCmd {
+            type_is: EventTargetType::Window,
+            name: ev_name.to_string(),
+            transmitter: tx,
+        });
     }
 
-    fn document_on(mut self, ev_name: &str, tx: Transmitter<Event>) -> Self {
-        let vev_name = ev_name.to_owned();
-        let vtx = tx.clone();
-        let hev_name = vev_name.clone();
-        self.append_update(
-            move |v| v.document_on(&vev_name, vtx),
-            move |v| v.document_on(&hev_name, tx),
-        );
-        self
+    fn document_on(&mut self, ev_name: &str, tx: Transmitter<Event>) {
+        self.events.push(EventTargetCmd {
+            type_is: EventTargetType::Document,
+            name: ev_name.to_string(),
+            transmitter: tx,
+        });
     }
 }
 
@@ -272,13 +464,9 @@ where
     P: JsCast + AsRef<Node> + 'static,
     C: JsCast + Clone + AsRef<Node> + 'static,
 {
-    fn with(mut self, child: ViewBuilder<C>) -> Self {
-        let ViewBuilder {
-            view_fn,
-            hydrate_fn,
-        } = child;
-        self.append_update(move |v| v.with(view_fn()), move |v| v.with(hydrate_fn()));
-        self
+    fn with(&mut self, child: ViewBuilder<C>) {
+        let child: ViewBuilder<Node> = child.to_node();
+        self.children.push(child);
     }
 }
 
@@ -289,9 +477,7 @@ where
 impl<T: JsCast + Clone + 'static> PostBuildView for ViewBuilder<T> {
     type DomNode = T;
 
-    fn post_build(mut self, tx: Transmitter<T>) -> Self {
-        let vtx = tx.clone();
-        self.append_update(move |v| v.post_build(vtx), move |v| v.post_build(tx));
-        self
+    fn post_build(&mut self, transmitter: Transmitter<T>) {
+        self.posts.push(transmitter);
     }
 }

--- a/mogwai/src/view/builder.rs
+++ b/mogwai/src/view/builder.rs
@@ -161,9 +161,17 @@ impl<T: IsDomNode + AsRef<Node>> From<ViewBuilder<T>> for View<T> {
         };
 
         {
+            fn has_type<X: IsDomNode>(val: &JsValue) -> bool {
+                if cfg!(target_arch = "wasm32") {
+                    val.has_type::<X>()
+                } else {
+                    true
+                }
+            }
+
             let mut internals = view.internals.borrow_mut();
 
-            if events.len() > 0 && internals.element.has_type::<EventTarget>() {
+            if events.len() > 0 && has_type::<EventTarget>(&internals.element) {
                 for cmd in events.into_iter() {
                     match cmd.type_is {
                         EventTargetType::Myself => {
@@ -179,13 +187,13 @@ impl<T: IsDomNode + AsRef<Node>> From<ViewBuilder<T>> for View<T> {
                 }
             }
 
-            if styles.len() > 0 && internals.element.has_type::<HtmlElement>() {
+            if styles.len() > 0 && has_type::<HtmlElement>(&internals.element) {
                 for cmd in styles.into_iter() {
                     internals.add_style(&cmd.name, cmd.effect);
                 }
             }
 
-            if attribs.len() > 0 && internals.element.has_type::<Element>() {
+            if attribs.len() > 0 && has_type::<Element>(&internals.element) {
                 for cmd in attribs.into_iter() {
                     match cmd {
                         AttributeCmd::Attrib { name, effect } => {

--- a/mogwai/src/view/builder.rs
+++ b/mogwai/src/view/builder.rs
@@ -128,7 +128,8 @@ where
             },
         };
 
-        if events.len() > 0 && view.has_type::<EventTarget>() {
+        let has_event_target = cfg!(not(target_arch = "wasm32")) || view.has_type::<EventTarget>();
+        if events.len() > 0 && has_event_target {
             let mut ev_view: View<EventTarget> = View::default();
             view.swap(&mut ev_view);
             for cmd in events.into_iter() {
@@ -141,7 +142,8 @@ where
             view.swap(&mut ev_view);
         }
 
-        if styles.len() > 0 && view.has_type::<HtmlElement>() {
+        let has_html_element = cfg!(not(target_arch = "wasm32")) || view.has_type::<HtmlElement>();
+        if styles.len() > 0 && has_html_element {
             let mut style_view: View<HtmlElement> = View::default();
             view.swap(&mut style_view);
             for cmd in styles.into_iter() {
@@ -150,7 +152,8 @@ where
             view.swap(&mut style_view);
         }
 
-        if attribs.len() > 0 && view.has_type::<Element>() {
+        let has_element = cfg!(not(target_arch = "wasm32")) || view.has_type::<Element>();
+        if attribs.len() > 0 && has_element {
             let mut att_view: View<Element> = View::default();
             view.swap(&mut att_view);
             for cmd in attribs.into_iter() {

--- a/mogwai/src/view/dom.rs
+++ b/mogwai/src/view/dom.rs
@@ -1,7 +1,5 @@
 //! Widgets for the browser.
-use std::{
-    cell::RefCell, collections::HashMap, marker::PhantomData, ops::Deref, rc::Rc,
-};
+use std::{cell::RefCell, collections::HashMap, marker::PhantomData, ops::Deref, rc::Rc};
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::closure::Closure;
 pub use wasm_bindgen::{JsCast, JsValue, UnwrapThrowExt};
@@ -9,7 +7,7 @@ pub use web_sys::{Element, Event, EventTarget, HtmlElement, HtmlInputElement};
 use web_sys::{Node, Text};
 
 use crate::{
-    prelude::{Component, Effect, Gizmo, Receiver, Transmitter, IsDomNode},
+    prelude::{Component, Effect, Gizmo, IsDomNode, Receiver, Transmitter},
     ssr::Node as SsrNode,
     utils,
     view::interface::*,
@@ -115,7 +113,7 @@ impl<T: IsDomNode> Default for View<T> {
                 name_or_text: NameOrText::Name(Rc::new(RefCell::new("".to_string()))),
                 attributes: vec![],
                 styles: vec![],
-            }
+            },
         }
     }
 }
@@ -202,12 +200,11 @@ impl<T: IsDomNode> View<T> {
     pub fn add_style(&mut self, name: &str, effect: Effect<String>) {
         let (may_now, may_later) = effect.into();
         if cfg!(target_arch = "wasm32") {
-            let t:T = {
-                let t:&T = &self;
+            let t: T = {
+                let t: &T = &self;
                 t.clone()
             };
             if let Ok(element) = t.dyn_into::<HtmlElement>() {
-
                 if let Some(now) = may_now {
                     element
                         .style()
@@ -253,12 +250,10 @@ impl<T: IsDomNode> View<T> {
     pub fn add_attribute(&mut self, name: &str, effect: Effect<String>) {
         let (may_now, may_later) = effect.into();
         if cfg!(target_arch = "wasm32") {
-            let t:&T = self.element.unchecked_ref();
+            let t: &T = self.element.unchecked_ref();
             if let Some(element) = t.dyn_ref::<Element>() {
                 if let Some(now) = may_now {
-                    element
-                        .set_attribute(name, &now)
-                        .unwrap_throw();
+                    element.set_attribute(name, &now).unwrap_throw();
                 }
                 if let Some(later) = may_later {
                     let rx = later;
@@ -302,12 +297,10 @@ impl<T: IsDomNode> View<T> {
     pub fn add_boolean_attribute(&mut self, name: &str, effect: Effect<bool>) {
         let (may_now, may_later) = effect.into();
         if cfg!(target_arch = "wasm32") {
-            let t:&T = self.element.unchecked_ref();
+            let t: &T = self.element.unchecked_ref();
             if let Some(element) = t.dyn_ref::<Element>() {
                 if let Some(true) = may_now {
-                    element
-                        .set_attribute(name, "")
-                        .unwrap_throw();
+                    element.set_attribute(name, "").unwrap_throw();
                 }
                 if let Some(later) = may_later {
                     let rx = later.branch();
@@ -453,7 +446,7 @@ impl<T: IsDomNode> View<T> {
             bool_rxs: std::mem::take(&mut self.bool_rxs),
             children: std::mem::take(&mut self.children),
 
-            server_node: self.server_node.clone()
+            server_node: self.server_node.clone(),
         })
     }
 
@@ -487,8 +480,7 @@ impl<T: IsDomNode> View<T> {
         }
     }
     #[cfg(not(target_arch = "wasm32"))]
-    fn clone_as<D: IsDomNode>(&self) -> View<D>
-    {
+    fn clone_as<D: IsDomNode>(&self) -> View<D> {
         View {
             phantom: PhantomData,
             element: self.element.clone(),
@@ -520,7 +512,8 @@ impl<T: IsDomNode> View<T> {
     /// Cast the given View to contain the inner DOM node of another type.
     /// That type must be dereferencable from the given View.
     pub fn upcast<D: IsDomNode>(self) -> View<D> {
-        self.try_cast::<D>().unwrap_or_else(|_| panic!(r#"can't upcast - impossible"#))
+        self.try_cast::<D>()
+            .unwrap_or_else(|_| panic!(r#"can't upcast - impossible"#))
     }
 
     /// Attempt to downcast the inner element.
@@ -867,9 +860,6 @@ impl<T: IsDomNode> PostBuildView for View<T> {
         tx.send_async(async move { t });
     }
 }
-
-
-
 
 
 /// View's Drop implementation insures that responders no longer attempt to

--- a/mogwai/src/view/dom.rs
+++ b/mogwai/src/view/dom.rs
@@ -716,7 +716,7 @@ where
     <T as Component>::DomNode: JsCast + AsRef<Node>,
 {
     fn from(gizmo: Gizmo<T>) -> Self {
-        gizmo.view
+        View::from(gizmo.view_builder())
     }
 }
 

--- a/mogwai/src/view/dom.rs
+++ b/mogwai/src/view/dom.rs
@@ -358,7 +358,7 @@ impl<T: IsDomNode> View<T> {
     }
     #[cfg(not(target_arch = "wasm32"))]
     pub fn into_html_string(self) -> String {
-        String::from(self.to_ssr_node());
+        String::from(self.to_ssr_node())
     }
 
     /// Create a new `View` wrapping a `T` that can be dereferenced to a `Node`.

--- a/mogwai/src/view/interface.rs
+++ b/mogwai/src/view/interface.rs
@@ -1,7 +1,8 @@
 //! Interfaces for constructing declarative views.
 pub use web_sys::{Element, Event, EventTarget, HtmlElement, HtmlInputElement};
 
-use crate::prelude::{Effect, Transmitter};
+use crate::prelude::{Effect, Receiver, Transmitter};
+
 
 /// `ElementView`s are views that represent DOM elements.
 pub trait ElementView {
@@ -56,7 +57,7 @@ pub trait AttributeView {
 
     /// Create (or remove) a boolean attribute on the view that may change its
     /// value every time the given receiver receives a message
-    /// If `eff` is a receiver and that receiver receives `false` it will
+    /// If `eff` contains a receiver and that receiver receives `false` it will
     /// respond by removing the attribute until it receives `true`. If `eff` is
     /// a single boolean value, either add or remove the attribute.
     fn boolean_attribute<E: Into<Effect<bool>>>(&mut self, name: &str, eff: E);
@@ -66,8 +67,8 @@ pub trait AttributeView {
 /// `StyleView`s can describe themselves using CSS style key value pairs.
 pub trait StyleView {
     /// Set a CSS property in the style attribute of the view being built.
-    /// If `eff` is a Receiver, this updates the style's value every time a
-    /// message is received on the given `Receiver`.
+    /// If `eff` contains a Receiver, messages received will updated the style's
+    /// value.
     fn style<E: Into<Effect<String>>>(&mut self, name: &str, eff: E);
 }
 
@@ -89,25 +90,60 @@ pub trait EventTargetView {
 }
 
 
-/// `ParentView`s can nest child views.
-pub trait ParentView<T> {
-    /// Add a child view to this parent.
-    fn with(&mut self, child: T);
-}
-
-
 /// `PostBuildView`s can send their underlying browser DOM node as a message on
 /// a Transmitter once they've been built.
 ///
-/// This allows you to construct component behaviors that operate on the constructed
+/// `PostBuildView` allows you to construct component behaviors that operate on the constructed
 /// node directly, while still keeping the definition in its place within your view
 /// builder function. For example, you may want to use `input.focus()` within the
 /// `update` function of your component. This method allows you to store the
-/// input `HtmlInputElement` once it is built.
+/// input `HtmlInputElement` once it is built, allowing you to use it as you see fit
+/// within your [`Component::update`] function.
 pub trait PostBuildView {
     type DomNode;
 
     /// After the view is built, transmit its underlying DomNode on the given
     /// transmitter.
     fn post_build(&mut self, tx: Transmitter<Self::DomNode>);
+}
+
+
+/// `ParentView`s can nest child views.
+pub trait ParentView<T> {
+    /// Add a child to this parent.
+    fn with(&mut self, view_now: T);
+}
+
+
+/// `ReplaceView`s can entirely replace themselves with views sent to a
+/// [`Receiver`].
+pub trait ReplaceView<T> {
+    fn this_later(&mut self, rx: Receiver<T>);
+}
+
+
+/// An enumeration of commands used to update the children of a [`PatchView`].
+#[derive(Clone, Debug)]
+pub enum Patch<T> {
+    Insert {
+        index: usize,
+        value: T
+    },
+    Remove {
+        index: usize
+    },
+    PushFront {
+        value: T
+    },
+    PushBack {
+        value: T
+    },
+    PopFront,
+    PopBack
+}
+
+
+/// `PatchView`s' children can be manipulated using patch commands sent on a [`Receiver`].
+pub trait PatchView<T> {
+    fn patch(&mut self, rx: Receiver<Patch<T>>);
 }

--- a/mogwai/src/view/interface.rs
+++ b/mogwai/src/view/interface.rs
@@ -13,6 +13,13 @@ pub trait ElementView {
 }
 
 
+/// `TextView`s are views that represent text nodes.
+pub trait TextView {
+    /// Create a new text node view.
+    fn text<E: Into<Effect<String>>>(eff: E) -> Self;
+}
+
+
 /// `AttributeView`s can describe themselves with key value pairs.
 pub trait AttributeView {
     /// Create a named attribute on the view that may change over time as
@@ -25,11 +32,11 @@ pub trait AttributeView {
     /// use mogwai::prelude::*;
     ///
     /// let (tx, rx) = txrx::<String>();
-    /// let my_div = (View::element("div") as View<HtmlElement>)
-    ///     .attribute("id", "my_div")
-    ///     .attribute("class", ("hero_div", rx.branch_map(|class_update| {
-    ///         ["hero_div", class_update].join(" ")
-    ///     })));
+    /// let mut my_div: View<HtmlElement> = View::element("div");
+    /// my_div.attribute("id", "my_div");
+    /// my_div.attribute("class", ("hero_div", rx.branch_map(|class_update| {
+    ///     ["hero_div", class_update].join(" ")
+    /// })));
     /// ```
     ///
     /// Alternatively you can use macros to define an equivalent view in RSX:
@@ -45,14 +52,14 @@ pub trait AttributeView {
     ///     })) />
     /// };
     /// ```
-    fn attribute<E: Into<Effect<String>>>(self, name: &str, eff: E) -> Self;
+    fn attribute<E: Into<Effect<String>>>(&mut self, name: &str, eff: E);
 
     /// Create (or remove) a boolean attribute on the view that may change its
     /// value every time the given receiver receives a message
     /// If `eff` is a receiver and that receiver receives `false` it will
     /// respond by removing the attribute until it receives `true`. If `eff` is
     /// a single boolean value, either add or remove the attribute.
-    fn boolean_attribute<E: Into<Effect<bool>>>(self, name: &str, eff: E) -> Self;
+    fn boolean_attribute<E: Into<Effect<bool>>>(&mut self, name: &str, eff: E);
 }
 
 
@@ -61,7 +68,7 @@ pub trait StyleView {
     /// Set a CSS property in the style attribute of the view being built.
     /// If `eff` is a Receiver, this updates the style's value every time a
     /// message is received on the given `Receiver`.
-    fn style<E: Into<Effect<String>>>(self, name: &str, eff: E) -> Self;
+    fn style<E: Into<Effect<String>>>(&mut self, name: &str, eff: E);
 }
 
 
@@ -70,22 +77,22 @@ pub trait StyleView {
 pub trait EventTargetView {
     /// Transmit an event message on the given transmitter when the named event
     /// happens.
-    fn on(self, ev_name: &str, tx: Transmitter<Event>) -> Self;
+    fn on(&mut self, ev_name: &str, tx: Transmitter<Event>);
 
     /// Transmit an event message on the given transmitter when the named event
     /// happens on [`Window`].
-    fn window_on(self, ev_name: &str, tx: Transmitter<Event>) -> Self;
+    fn window_on(&mut self, ev_name: &str, tx: Transmitter<Event>);
 
     /// Transmit an event message into the given transmitter when the named event
     /// happens on [`Document`].
-    fn document_on(self, ev_name: &str, tx: Transmitter<Event>) -> Self;
+    fn document_on(&mut self, ev_name: &str, tx: Transmitter<Event>);
 }
 
 
 /// `ParentView`s can nest child views.
 pub trait ParentView<T> {
     /// Add a child view to this parent.
-    fn with(self, child: T) -> Self;
+    fn with(&mut self, child: T);
 }
 
 
@@ -102,5 +109,5 @@ pub trait PostBuildView {
 
     /// After the view is built, transmit its underlying DomNode on the given
     /// transmitter.
-    fn post_build(self, tx: Transmitter<Self::DomNode>) -> Self;
+    fn post_build(&mut self, tx: Transmitter<Self::DomNode>);
 }

--- a/mogwai/src/view/interface.rs
+++ b/mogwai/src/view/interface.rs
@@ -129,9 +129,14 @@ pub enum Patch<T> {
         index: usize,
         value: T
     },
+    Replace {
+        index: usize,
+        value: T
+    },
     Remove {
         index: usize
     },
+    RemoveAll,
     PushFront {
         value: T
     },

--- a/mogwai/src/view/interface.rs
+++ b/mogwai/src/view/interface.rs
@@ -118,7 +118,7 @@ pub trait ParentView<T> {
 /// `ReplaceView`s can entirely replace themselves with views sent to a
 /// [`Receiver`].
 pub trait ReplaceView<T> {
-    fn this_later(&mut self, rx: Receiver<T>);
+    fn this_later<S:Clone + Into<T>>(&mut self, rx: Receiver<S>);
 }
 
 
@@ -150,5 +150,5 @@ pub enum Patch<T> {
 
 /// `PatchView`s' children can be manipulated using patch commands sent on a [`Receiver`].
 pub trait PatchView<T> {
-    fn patch(&mut self, rx: Receiver<Patch<T>>);
+    fn patch<S:Clone + Into<T>>(&mut self, rx: Receiver<Patch<S>>);
 }

--- a/mogwai/tests/wasm.rs
+++ b/mogwai/tests/wasm.rs
@@ -5,7 +5,9 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 use web_sys::Element;
 
+
 wasm_bindgen_test_configure!(run_in_browser);
+
 
 #[wasm_bindgen_test]
 fn this_arch_is_wasm32() {
@@ -42,7 +44,7 @@ fn gizmo_as_child() {
         let div = view! {
             <div id="parent-div">
                 <pre>"some text"</pre>
-            </div>
+                </div>
         };
         assert!(div.first_child().is_some(), "could not add child gizmo");
         div
@@ -60,11 +62,11 @@ fn gizmo_tree() {
     let root = view! {
         <div id="root">
             <div id="branch">
-                <div id="leaf">
-                    "leaf"
-                </div>
+            <div id="leaf">
+            "leaf"
             </div>
-        </div>
+            </div>
+            </div>
     };
     if let Some(branch) = root.first_child() {
         if let Some(leaf) = branch.first_child() {
@@ -86,10 +88,10 @@ fn gizmo_texts() {
     let div = view! {
         <div>
             "here is some text "
-            // i can use comments, yay!
-            {&format!("{}", 66)}
-            " <- number"
-        </div>
+        // i can use comments, yay!
+        {&format!("{}", 66)}
+        " <- number"
+            </div>
     };
     assert_eq!(
         &div.outer_html(),
@@ -142,7 +144,7 @@ fn rx_style_jsx() {
 }
 
 #[wasm_bindgen_test]
-fn rx_text() {
+pub fn rx_text() {
     let (tx, rx) = txrx();
 
     let mut div: View<HtmlElement> = View::element("div");
@@ -216,7 +218,7 @@ fn tx_window_on_click_jsx() {
 
 #[test]
 #[wasm_bindgen_test]
-fn can_i_alter_views_on_the_server() {
+pub fn can_i_alter_views_on_the_server() {
     let (tx_text, rx_text) = txrx::<String>();
     let (tx_style, rx_style) = txrx::<String>();
     let (tx_class, rx_class) = txrx::<String>();
@@ -253,7 +255,7 @@ fn can_hydrate_view() {
     let original_view = view! {
         <div id="my_div">
             <p class="class">"inner text"</p>
-        </div>
+            </div>
     };
     let original_el: HtmlElement = (original_view.as_ref() as &HtmlElement).clone();
     original_view.run().unwrap();
@@ -263,7 +265,7 @@ fn can_hydrate_view() {
     let hydrated_view = View::try_from(hydrate! {
         <div id="my_div">
             <p class=("unused_class", rx_class)>{("unused inner text", rx_text)}</p>
-        </div>
+            </div>
     })
     .unwrap();
 
@@ -296,14 +298,14 @@ fn can_hydrate_or_view() {
         view! {
             <div id="my_div" post:build=(&tx_pb).clone()>
                 <p class=("class", rx_class.branch())>{("inner text", rx_text.branch())}</p>
-            </div>
+                </div>
         }
     };
     let hydrate_view = || {
         View::try_from(hydrate! {
             <div id="my_div" post:build=(&tx_pb).clone()>
                 <p class=("class", rx_class.branch())>{("inner text", rx_text.branch())}</p>
-            </div>
+                </div>
         })
     };
 

--- a/mogwai/tests/wasm.rs
+++ b/mogwai/tests/wasm.rs
@@ -1,0 +1,327 @@
+#![allow(unused_braces)]
+use mogwai::prelude::*;
+use mogwai_html_macro::target_arch_is_wasm32;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::*;
+use web_sys::Element;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn this_arch_is_wasm32() {
+    assert!(target_arch_is_wasm32! {});
+}
+
+#[wasm_bindgen_test]
+fn gizmo_ref_as_child() {
+    // Since the pre tag is dropped after the scope block the last assert should
+    // show that the div tag has no children.
+    let div = {
+        let pre = view! { <pre>"this has text"</pre> };
+        let div = view! { <div id="parent"></div> };
+        (div.as_ref() as &Node).append_child(pre.as_ref()).unwrap();
+        assert!(
+            div.first_child().is_some(),
+            "parent does not contain in-scope child"
+        );
+        //console::log_1(&"dropping pre".into());
+        div
+    };
+    assert!(
+        div.first_child().is_none(),
+        "parent does not maintain out-of-scope child"
+    );
+    //console::log_1(&"dropping parent".into());
+}
+
+#[wasm_bindgen_test]
+fn gizmo_as_child() {
+    // Since the pre tag is *not* dropped after the scope block the last assert
+    // should show that the div tag has a child.
+    let div = {
+        let div = view! {
+            <div id="parent-div">
+                <pre>"some text"</pre>
+            </div>
+        };
+        assert!(div.first_child().is_some(), "could not add child gizmo");
+        div
+    };
+    assert!(
+        div.first_child().is_some(),
+        "could not keep hold of child gizmo"
+    );
+    assert_eq!(div.children.len(), 1, "parent is missing static_gizmo");
+    //console::log_1(&"dropping div and pre".into());
+}
+
+#[wasm_bindgen_test]
+fn gizmo_tree() {
+    let root = view! {
+        <div id="root">
+            <div id="branch">
+                <div id="leaf">
+                    "leaf"
+                </div>
+            </div>
+        </div>
+    };
+    if let Some(branch) = root.first_child() {
+        if let Some(leaf) = branch.first_child() {
+            if let Some(leaf) = leaf.dyn_ref::<Element>() {
+                assert_eq!(leaf.id(), "leaf");
+            } else {
+                panic!("leaf is not an Element");
+            }
+        } else {
+            panic!("branch has no leaf");
+        }
+    } else {
+        panic!("root has no branch");
+    }
+}
+
+#[wasm_bindgen_test]
+fn gizmo_texts() {
+    let div = view! {
+        <div>
+            "here is some text "
+            // i can use comments, yay!
+            {&format!("{}", 66)}
+            " <- number"
+        </div>
+    };
+    assert_eq!(
+        &div.outer_html(),
+        "<div>here is some text 66 &lt;- number</div>"
+    );
+}
+
+#[wasm_bindgen_test]
+fn rx_attribute_jsx() {
+    let (tx, rx) = txrx::<String>();
+    let div = view! {
+        <div class=("now", rx) />
+    };
+    let div_el: &HtmlElement = div.as_ref();
+    assert_eq!(div_el.outer_html(), r#"<div class="now"></div>"#);
+
+    tx.send(&"later".to_string());
+    assert_eq!(div_el.outer_html(), r#"<div class="later"></div>"#);
+}
+
+#[wasm_bindgen_test]
+fn rx_style_plain() {
+    let (tx, rx) = txrx::<String>();
+
+    let mut div: View<HtmlElement> = View::element("div");
+    div.style("display", ("block", rx));
+
+    let div_el: &HtmlElement = div.as_ref();
+    assert_eq!(
+        div_el.outer_html(),
+        r#"<div style="display: block;"></div>"#
+    );
+
+    tx.send(&"none".to_string());
+    assert_eq!(div_el.outer_html(), r#"<div style="display: none;"></div>"#);
+}
+
+#[wasm_bindgen_test]
+fn rx_style_jsx() {
+    let (tx, rx) = txrx::<String>();
+    let div = view! { <div style:display=("block", rx) /> };
+    let div_el: &HtmlElement = div.as_ref();
+    assert_eq!(
+        div_el.outer_html(),
+        r#"<div style="display: block;"></div>"#
+    );
+
+    tx.send(&"none".to_string());
+    assert_eq!(div_el.outer_html(), r#"<div style="display: none;"></div>"#);
+}
+
+#[wasm_bindgen_test]
+fn rx_text() {
+    let (tx, rx) = txrx();
+
+    let mut div: View<HtmlElement> = View::element("div");
+    div.with(("initial", rx).into());
+
+    let el: &HtmlElement = div.as_ref();
+    assert_eq!(el.inner_text().as_str(), "initial");
+    tx.send(&"after".into());
+    assert_eq!(el.inner_text(), "after");
+}
+
+#[wasm_bindgen_test]
+fn tx_on_click_plain() {
+    let (tx, rx) = txrx_fold(0, |n: &mut i32, _: &Event| -> String {
+        *n += 1;
+        if *n == 1 {
+            "Clicked 1 time".to_string()
+        } else {
+            format!("Clicked {} times", *n)
+        }
+    });
+
+    let mut button: View<HtmlElement> = View::element("button");
+    button.with(("Clicked 0 times", rx).into());
+    button.on("click", tx);
+
+    let el: &HtmlElement = button.as_ref();
+    assert_eq!(el.inner_html(), "Clicked 0 times");
+    el.click();
+    assert_eq!(el.inner_html(), "Clicked 1 time");
+}
+
+#[wasm_bindgen_test]
+fn tx_on_click_jsx() {
+    let (tx, rx) = txrx_fold(0, |n: &mut i32, _: &Event| -> String {
+        *n += 1;
+        if *n == 1 {
+            "Clicked 1 time".to_string()
+        } else {
+            format!("Clicked {} times", *n)
+        }
+    });
+
+    let button = view! { <button on:click=tx>{("Clicked 0 times", rx)}</button> };
+    let el: &HtmlElement = button.as_ref();
+
+    assert_eq!(el.inner_html(), "Clicked 0 times");
+    el.click();
+    assert_eq!(el.inner_html(), "Clicked 1 time");
+}
+
+
+#[wasm_bindgen_test]
+fn tx_window_on_click_jsx() {
+    let (tx, rx) = txrx();
+    let _button = view! {
+        <button window:load=tx>
+        {(
+            "Waiting...",
+            rx.branch_map(|_| "Loaded!".into())
+        )}
+        </button>
+    };
+}
+
+//fn nice_compiler_error() {
+//    let _div = view! {
+//        <div unknown:colon:thing="not ok" />
+//    };
+//}
+
+#[test]
+#[wasm_bindgen_test]
+fn can_i_alter_views_on_the_server() {
+    let (tx_text, rx_text) = txrx::<String>();
+    let (tx_style, rx_style) = txrx::<String>();
+    let (tx_class, rx_class) = txrx::<String>();
+    let view = view! {
+        <div style:float=("left", rx_style)><p class=("p_class", rx_class)>{("here", rx_text)}</p></div>
+    };
+    assert_eq!(
+        &view.clone().into_html_string(),
+        r#"<div style="float: left;"><p class="p_class">here</p></div>"#
+    );
+
+    tx_text.send(&"there".to_string());
+    assert_eq!(
+        &view.clone().into_html_string(),
+        r#"<div style="float: left;"><p class="p_class">there</p></div>"#
+    );
+
+    tx_style.send(&"right".to_string());
+    assert_eq!(
+        &view.clone().into_html_string(),
+        r#"<div style="float: right;"><p class="p_class">there</p></div>"#
+    );
+
+    tx_class.send(&"my_p_class".to_string());
+    assert_eq!(
+        &view.clone().into_html_string(),
+        r#"<div style="float: right;"><p class="my_p_class">there</p></div>"#
+    );
+}
+
+
+#[wasm_bindgen_test]
+fn can_hydrate_view() {
+    let original_view = view! {
+        <div id="my_div">
+            <p class="class">"inner text"</p>
+        </div>
+    };
+    let original_el: HtmlElement = (original_view.as_ref() as &HtmlElement).clone();
+    original_view.run().unwrap();
+
+    let (tx_class, rx_class) = txrx::<String>();
+    let (tx_text, rx_text) = txrx::<String>();
+    let hydrated_view = View::try_from(hydrate! {
+        <div id="my_div">
+            <p class=("unused_class", rx_class)>{("unused inner text", rx_text)}</p>
+        </div>
+    })
+    .unwrap();
+
+    hydrated_view.forget().unwrap();
+
+    tx_class.send(&"new_class".to_string());
+    tx_text.send(&"different inner text".to_string());
+
+    assert_eq!(
+        original_el.outer_html().as_str(),
+        r#"<div id="my_div"><p class="new_class">different inner text</p></div>"#
+    );
+}
+
+
+#[wasm_bindgen_test]
+fn can_hydrate_or_view() {
+    let (tx_class, rx_class) = txrx::<String>();
+    let (tx_text, rx_text) = txrx::<String>();
+    let count = txrx::new_shared(0 as u32);
+    let (tx_pb, rx_pb) =
+        txrx_fold_shared(count.clone(), |count: &mut u32, _: &HtmlElement| -> () {
+            *count += 1;
+            ()
+        });
+
+    rx_pb.respond(|_| println!("post build"));
+
+    let fresh_view = || {
+        view! {
+            <div id="my_div" post:build=(&tx_pb).clone()>
+                <p class=("class", rx_class.branch())>{("inner text", rx_text.branch())}</p>
+            </div>
+        }
+    };
+    let hydrate_view = || {
+        View::try_from(hydrate! {
+            <div id="my_div" post:build=(&tx_pb).clone()>
+                <p class=("class", rx_class.branch())>{("inner text", rx_text.branch())}</p>
+            </div>
+        })
+    };
+
+    let view = fresh_view();
+
+    let original_el: HtmlElement = (view.as_ref() as &HtmlElement).clone();
+    view.run().unwrap();
+
+    let hydrated_view = hydrate_view().unwrap();
+    hydrated_view.forget().unwrap();
+
+    tx_class.send(&"new_class".to_string());
+    tx_text.send(&"different inner text".to_string());
+
+    assert_eq!(
+        original_el.outer_html().as_str(),
+        r#"<div id="my_div"><p class="new_class">different inner text</p></div>"#
+    );
+
+    assert_eq!(*count.borrow(), 2);
+}

--- a/mogwai/tests/wasm.rs
+++ b/mogwai/tests/wasm.rs
@@ -489,4 +489,16 @@ async fn can_patch_children() {
         dom.outer_html().as_str(),
         r#"<ol id="main"><li>Negative One</li><li>Zero</li></ol>"#
     );
+
+    tx.send(&Patch::Replace{ index: 1, value: view!{<li>"One"</li>}});
+    assert_eq!(
+        dom.outer_html().as_str(),
+        r#"<ol id="main"><li>Negative One</li><li>One</li></ol>"#
+    );
+
+    tx.send(&Patch::RemoveAll);
+    assert_eq!(
+        dom.outer_html().as_str(),
+        r#"<ol id="main"></ol>"#
+    );
 }

--- a/mogwai/tests/wasm.rs
+++ b/mogwai/tests/wasm.rs
@@ -502,3 +502,33 @@ async fn can_patch_children() {
         r#"<ol id="main"></ol>"#
     );
 }
+
+#[wasm_bindgen_test]
+fn can_patch_children_into() {
+    let (tx, rx) = txrx::<Patch<String>>();
+    let view = view!{
+        <p id="main" patch:children=rx>
+            "Zero ""One"
+        </p>
+    };
+
+    let dom: HtmlElement = view.dom_ref().clone();
+    view.run().unwrap();
+
+    assert_eq!(
+        dom.outer_html().as_str(),
+        r#"<p id="main">Zero One</p>"#
+    );
+
+    tx.send(&Patch::PushFront{ value: "First ".to_string() });
+    assert_eq!(
+        dom.outer_html().as_str(),
+        r#"<p id="main">First Zero One</p>"#
+    );
+
+    tx.send(&Patch::RemoveAll);
+    assert_eq!(
+        dom.outer_html().as_str(),
+        r#"<p id="main"></p>"#
+    );
+}

--- a/mogwai/webdriver.json
+++ b/mogwai/webdriver.json
@@ -1,0 +1,9 @@
+{
+  "moz:firefoxOptions": {
+    "prefs": {},
+    "args": []
+  },
+  "goog:chromeOptions": {
+    "args": []
+  }
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,5 +4,6 @@ ROOT="$(git rev-parse --show-toplevel)"
 . $ROOT/scripts/common.sh
 
 cargo build || exit 1
+for DIR in examples/*/; do wasm-pack build --debug --target web $DIR; done
 
 echo "Done building on ref ${GITHUB_REF}"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,6 +4,11 @@ ROOT="$(git rev-parse --show-toplevel)"
 . $ROOT/scripts/common.sh
 
 cargo build || exit 1
-for DIR in examples/*/; do wasm-pack build --debug --target web $DIR; done
+for DIR in examples/*/
+do
+    echo ""
+    echo "Building '${DIR}'"
+    wasm-pack build --debug --target web $DIR
+done
 
 echo "Done building on ref ${GITHUB_REF}"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -16,5 +16,12 @@ else
     curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 fi
 
+if hash mdbook 2>/dev/null; then
+    echo "Have mdbook, skipping installation..."
+else
+    echo "Installing mdbook..."
+    cargo install mdbook
+fi
+
 rustup toolchain install 1.46.0
 rustup default 1.46.0

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,7 +7,4 @@ cargo test || exit 1
 cargo doc || exit 1
 wasm-pack test --firefox --headless mogwai || exit 1
 
-cargo build --package cookbook --target-dir cookbook_target --lib || exit 1
-mdbook test cookbook -L cookbook_target/debug/deps || exit 1
-
 echo "Done testing on ref ${GITHUB_REF}"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,6 +6,8 @@ ROOT="$(git rev-parse --show-toplevel)"
 cargo test || exit 1
 cargo doc || exit 1
 wasm-pack test --firefox --headless mogwai || exit 1
-mdbook test cookbook -L target/debug/deps || exit 1
+
+cargo build --package cookbook --target-dir cookbook_target --lib || exit 1
+mdbook test cookbook -L cookbook_target/debug/deps || exit 1
 
 echo "Done testing on ref ${GITHUB_REF}"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,6 +5,13 @@ ROOT="$(git rev-parse --show-toplevel)"
 
 cargo test || exit 1
 cargo doc || exit 1
-wasm-pack test --firefox --headless mogwai || exit 1
+
+# only test headless at github
+if [ -z ${GITHUB_REF+x} ]
+then
+    echo "Skipping headless wasm tests"
+else
+    wasm-pack test --firefox --headless mogwai || exit 1
+fi
 
 echo "Done testing on ref ${GITHUB_REF}"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,6 +5,7 @@ ROOT="$(git rev-parse --show-toplevel)"
 
 cargo test || exit 1
 cargo doc || exit 1
-wasm-pack test --firefox --headless mogwai
+wasm-pack test --firefox --headless mogwai || exit 1
+mdbook test cookbook -L target/debug/deps || exit 1
 
 echo "Done testing on ref ${GITHUB_REF}"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,5 +5,6 @@ ROOT="$(git rev-parse --show-toplevel)"
 
 cargo test || exit 1
 cargo doc || exit 1
+wasm-pack test --firefox --headless mogwai
 
 echo "Done testing on ref ${GITHUB_REF}"

--- a/scripts/test_cookbook.sh
+++ b/scripts/test_cookbook.sh
@@ -3,6 +3,6 @@
 ROOT="$(git rev-parse --show-toplevel)"
 . $ROOT/scripts/common.sh
 
-mdbook test cookbook -L target/debug/deps || (cargo clean && cargo build --package cookbook --lib && mdbook test cookbook -L target/debug/deps)
+cargo clean && mdbook test cookbook -L target/debug/deps
 
 echo "Done testing on ref ${GITHUB_REF}"

--- a/scripts/test_cookbook.sh
+++ b/scripts/test_cookbook.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+ROOT="$(git rev-parse --show-toplevel)"
+. $ROOT/scripts/common.sh
+
+mdbook test cookbook -L target/debug/deps || (cargo clean && cargo build --package cookbook --lib && mdbook test cookbook -L target/debug/deps)
+
+echo "Done testing on ref ${GITHUB_REF}"


### PR DESCRIPTION
* **less allocation during DOM construction** We now use a `ViewBuilder` to build up a DOM representation before constructing the DOM, which should alloc less memory and hopefully get a little speed up because of it.
* **view API is mutable** The view interface functions now use `&mut self` instead of `self -> Self`. This helps with some lifetime handling.   
* **view hydration is handled by an optional crate** You shouldn't have to pay for view hydration if you don't use it.
* **this:later attribute for views** Views can replace themselves in the DOM using a `Receiver<Into<View<T>>>`: 
  `<main this:later=rx>"Placeholder"</main>`
* **patch:children attribute for views** Views can patch their children using a `Receiver<Patch<Into<View<T>>>`: 
  `<main patch:children=rx>"child one " "child two " "child three"</main>`
* various other memory-related updates 