### PR TITLE
Define `Transmitter::send_async` separately for non-wasm32 architecture

### DIFF
--- a/mogwai/src/component/subscriber.rs
+++ b/mogwai/src/component/subscriber.rs
@@ -1,6 +1,5 @@
 //! A very limited transmitter used to map messages.
 use super::super::txrx::{Receiver, Transmitter};
-use std::future::Future;
 
 /// A subscriber allows a component to subscribe to other components' messages
 /// without having explicit access to both Transmitter and Receiver. This allows
@@ -43,9 +42,10 @@ impl<Msg: Clone + 'static> Subscriber<Msg> {
     }
 
     /// Send a one-time asynchronous message.
+    #[cfg(target_arch = "wasm32")]
     pub fn send_async<F>(&self, f: F)
     where
-        F: Future<Output = Msg> + 'static,
+        F: std::future::Future<Output = Msg> + 'static,
     {
         self.tx.send_async(f);
     }

--- a/mogwai/src/view/dom.rs
+++ b/mogwai/src/view/dom.rs
@@ -850,11 +850,14 @@ impl<T: IsDomNode> PostBuildView for View<T> {
     type DomNode = T;
 
     fn post_build(&mut self, tx: Transmitter<T>) {
-        let t: Ref<T> = Ref::map(self.internals.borrow(), |internals| {
-            internals.element.unchecked_ref()
-        });
-        let t: T = t.clone();
-        tx.send_async(async move { t });
+        #[cfg(target_arch = "wasm32")]
+        {
+            let t: Ref<T> = Ref::map(self.internals.borrow(), |internals| {
+                internals.element.unchecked_ref()
+            });
+            let t: T = t.clone();
+            tx.send_async(async move { t });
+        }
     }
 }
 


### PR DESCRIPTION
The wasm32 architecture relies on `wasm_bindgen_futures` which is only available for the wasm32 target_arch, non-wasm32 uses `futures` to block until the `Future` completes and then sends the result.

Refs #52 