### PR TITLE
Voidable nodes

### DIFF
--- a/crates/mogwai-html-macro/tests/integration_test.rs
+++ b/crates/mogwai-html-macro/tests/integration_test.rs
@@ -3,17 +3,29 @@ use mogwai::prelude::*;
 
 #[test]
 fn node_self_closing() {
+    // not all nodes are void nodes
     let div: String = view! {
         <a href="http://zyghost.com" />
     }
     .html_string();
-    assert_eq!(&div, r#"<a href="http://zyghost.com" />"#);
+    assert_eq!(&div, r#"<a href="http://zyghost.com"></a>"#);
+
+    let div: String = view! {
+        <img src="http://zyghost.com/favicon.ico" />
+    }
+    .html_string();
+    assert_eq!(&div, r#"<img src="http://zyghost.com/favicon.ico" />"#);
+
 }
 
 #[test]
 fn node_self_closing_gt_1_att() {
+    // not all nodes are void nodes
     let div: String = view! {<a href="http://zyghost.com" class="blah"/>}.html_string();
-    assert_eq!(&div, r#"<a href="http://zyghost.com" class="blah" />"#);
+    assert_eq!(&div, r#"<a href="http://zyghost.com" class="blah"></a>"#);
+
+    let div: String = view! {<img src="http://zyghost.com/favicon.ico" class="blah"/>}.html_string();
+    assert_eq!(&div, r#"<img src="http://zyghost.com/favicon.ico" class="blah" />"#);
 }
 
 #[test]

--- a/mogwai/src/ssr.rs
+++ b/mogwai/src/ssr.rs
@@ -1,3 +1,44 @@
+//! Provides string rendering for server-side mogwai nodes.
+
+/// Only certain nodes can be "void" - which means written as <tag /> when
+/// the node contains no children. Writing non-void nodes in void notation
+/// does some spooky things to the DOM at parse-time.
+///
+/// From https://riptutorial.com/html/example/4736/void-elements
+/// HTML 4.01/XHTML 1.0 Strict includes the following void elements:
+///
+///     area - clickable, defined area in an image
+///     base - specifies a base URL from which all links base
+///     br - line break
+///     col - column in a table [deprecated]
+///     hr - horizontal rule (line)
+///     img - image
+///     input - field where users enter data
+///     link - links an external resource to the document
+///     meta - provides information about the document
+///     param - defines parameters for plugins
+///
+///     HTML 5 standards include all non-deprecated tags from the previous list and
+///
+///     command - represents a command users can invoke [obsolete]
+///     keygen - facilitates public key generation for web certificates [deprecated]
+///     source - specifies media sources for picture, audio, and video elements
+fn tag_is_voidable(tag: &str) -> bool {
+    tag == "area"
+        || tag == "base"
+        || tag == "br"
+        || tag == "col"
+        || tag == "hr"
+        || tag == "img"
+        || tag == "input"
+        || tag == "link"
+        || tag == "meta"
+        || tag == "param"
+        || tag == "command"
+        || tag == "keygen"
+        || tag == "source"
+}
+
 #[derive(Debug)]
 pub enum Node {
     Text(String),
@@ -31,9 +72,17 @@ impl From<Node> for String {
 
                 if children.is_empty() {
                     if attributes.is_empty() {
-                        format!("<{} />", name)
+                        if tag_is_voidable(&name) {
+                            format!("<{} />", name)
+                        } else {
+                            format!("<{}></{}>", name, name)
+                        }
                     } else {
-                        format!("<{} {} />", name, atts)
+                        if tag_is_voidable(&name) {
+                            format!("<{} {} />", name, atts)
+                        } else {
+                            format!("<{} {}></{}>", name, atts, name)
+                        }
                     }
                 } else {
                     let kids = children

--- a/mogwai/src/ssr.rs
+++ b/mogwai/src/ssr.rs
@@ -1,28 +1,28 @@
 //! Provides string rendering for server-side mogwai nodes.
 
-/// Only certain nodes can be "void" - which means written as <tag /> when
-/// the node contains no children. Writing non-void nodes in void notation
-/// does some spooky things to the DOM at parse-time.
-///
-/// From https://riptutorial.com/html/example/4736/void-elements
-/// HTML 4.01/XHTML 1.0 Strict includes the following void elements:
-///
-///     area - clickable, defined area in an image
-///     base - specifies a base URL from which all links base
-///     br - line break
-///     col - column in a table [deprecated]
-///     hr - horizontal rule (line)
-///     img - image
-///     input - field where users enter data
-///     link - links an external resource to the document
-///     meta - provides information about the document
-///     param - defines parameters for plugins
-///
-///     HTML 5 standards include all non-deprecated tags from the previous list and
-///
-///     command - represents a command users can invoke [obsolete]
-///     keygen - facilitates public key generation for web certificates [deprecated]
-///     source - specifies media sources for picture, audio, and video elements
+// Only certain nodes can be "void" - which means written as <tag /> when
+// the node contains no children. Writing non-void nodes in void notation
+// does some spooky things to the DOM at parse-time.
+//
+// From https://riptutorial.com/html/example/4736/void-elements
+// HTML 4.01/XHTML 1.0 Strict includes the following void elements:
+//
+//     rea - clickable, defined area in an image
+//     base - specifies a base URL from which all links base
+//     br - line break
+//     col - column in a table [deprecated]
+//     hr - horizontal rule (line)
+//     img - image
+//     input - field where users enter data
+//     link - links an external resource to the document
+//     meta - provides information about the document
+//     param - defines parameters for plugins
+//
+//     HTML 5 standards include all non-deprecated tags from the previous list and
+//
+//     command - represents a command users can invoke [obsolete]
+//     keygen - facilitates public key generation for web certificates [deprecated]
+//     source - specifies media sources for picture, audio, and video elements
 fn tag_is_voidable(tag: &str) -> bool {
     tag == "area"
         || tag == "base"


### PR DESCRIPTION
Only some nodes are voidable. When writing a non-voidable node in voidable notation some browsers do weird things like assume the author meant to keep the node open. Yikes!

This change ensures that nodes rendered server-side will respect that only some nodes are voidable and will write the correct closing tag. 