### PR TITLE
models, bind update

### DIFF
--- a/cookbook/Cargo.toml
+++ b/cookbook/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mogwai = { path = "../mogwai", version = "^0.3" }
+mogwai = { path = "../mogwai", version = "^0.4" }
 
 [dependencies.web-sys]
 version = "^0.3"

--- a/crates/mogwai-hydrator/Cargo.toml
+++ b/crates/mogwai-hydrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mogwai-hydrator"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Schell Scivally <efsubenovex@gmail.com>"]
 edition = "2018"
 description = "View hydration for the mogwai library"
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/mogwai/"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mogwai = { path = "../../mogwai", version = "^0.3" }
+mogwai = { path = "../../mogwai", version = "^0.4" }
 snafu = "^0.6"
 wasm-bindgen = "^0.2"
 

--- a/examples/list-of-gizmos/Cargo.toml
+++ b/examples/list-of-gizmos/Cargo.toml
@@ -31,7 +31,7 @@ console_error_panic_hook = { version = "0.1.6", optional = true }
 wee_alloc = { version = "0.4.2", optional = true }
 
 [dependencies.mogwai]
-version = "^0.3"
+version = "^0.4"
 path = "../../mogwai"
 
 [dependencies.web-sys]

--- a/examples/svg/Cargo.toml
+++ b/examples/svg/Cargo.toml
@@ -31,7 +31,7 @@ console_error_panic_hook = { version = "0.1.6", optional = true }
 wee_alloc = { version = "0.4.2", optional = true }
 
 [dependencies.mogwai]
-version = "^0.3"
+version = "^0.4"
 path = "../../mogwai"
 
 [dependencies.web-sys]

--- a/mogwai/Cargo.toml
+++ b/mogwai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mogwai"
-version = "0.3.6"
+version = "0.4.0"
 authors = ["Schell Scivally <efsubenovex@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/mogwai/src/component.rs
+++ b/mogwai/src/component.rs
@@ -170,6 +170,14 @@ where
     /// ie HtmlElement, HtmlInputElement, etc.
     type DomNode;
 
+    /// Used to perform any one-time binding from in scope [`Gizmo`]s or [`Model`]s to this component's subscribers.
+    ///
+    /// This function will be called only once, after a [`Gizmo`] is converted from the
+    /// type implementing `Component`.
+    #[allow(unused_variables)]
+    fn bind(&self, input_sub: &Subscriber<Self::ModelMsg>, output_sub: &Subscriber<Self::ViewMsg>) {
+    }
+
     /// Update this component in response to any received model messages.
     /// This is essentially the component's fold function.
     fn update(
@@ -189,15 +197,4 @@ where
         tx: &Transmitter<Self::ModelMsg>,
         rx: &Receiver<Self::ViewMsg>,
     ) -> ViewBuilder<Self::DomNode>;
-
-    /// Used to perform any one-time binding from in scope [`Gizmo`]s to this component's subscriber.
-    ///
-    /// This should be used to bind sub-component view messages into this parent component's
-    /// model messages in order to receive updates from child components. The default implementation
-    /// is a noop.
-    ///
-    /// This function will be called only once, after a [`Gizmo`] is converted from the
-    /// type implementing `Component`.
-    #[allow(unused_variables)]
-    fn bind(&self, sub: &Subscriber<Self::ModelMsg>) {}
 }

--- a/mogwai/src/lib.rs
+++ b/mogwai/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod an_introduction;
 pub mod component;
 pub mod gizmo;
+pub mod model;
 pub mod prelude;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod ssr;

--- a/mogwai/src/model.rs
+++ b/mogwai/src/model.rs
@@ -1,0 +1,82 @@
+//! Data that transmits updates to subscribers automatically.
+use crate::txrx::*;
+use std::{cell::RefCell, rc::Rc};
+
+/// Wraps a value `T` and transmits updates to subscribers.
+#[derive(Clone)]
+pub struct Model<T> {
+    value: Rc<RefCell<T>>,
+    trns: Transmitter<T>,
+    recv: Receiver<T>,
+}
+
+impl<T: Clone + 'static> Model<T> {
+    /// Create a new model from a `T`.
+    pub fn new(t: T) -> Model<T> {
+        let (trns, recv) = txrx::<T>();
+        Model {
+            value: Rc::new(RefCell::new(t)),
+            trns,
+            recv,
+        }
+    }
+
+    /// Manually transmitter the inner value of this model to subscribers.
+    pub fn transmit(&self) {
+        self.trns.send(&self.value.as_ref().borrow());
+    }
+
+    /// Visit the wrapped value with a function that produces a value.
+    pub fn visit<F, A>(&self, f: F) -> A
+    where
+        A: 'static,
+        F: FnOnce(&T) -> A,
+    {
+        f(&self.value.borrow())
+    }
+
+    /// Visit the mutable wrapped value with a function that produces a value.
+    pub fn visit_mut<F, A>(&self, f: F) -> A
+    where
+        A: 'static,
+        F: FnOnce(&mut T) -> A,
+    {
+        let a = f(&mut self.value.borrow_mut());
+        self.transmit();
+        a
+    }
+
+    /// Replaces the wrapped value with a new one, returning the old value, without deinitializing either one.
+    ///
+    /// This function corresponds to std::mem::replace.
+    pub fn replace(&self, t: T) -> T {
+        let t = self.value.replace(t);
+        self.transmit();
+        t
+    }
+
+    /// Replaces the wrapped value with a new one computed from f, returning the old value, without deinitializing either one.
+    pub fn replace_with<F>(&self, f: F) -> T
+    where
+        F: FnOnce(&mut T) -> T,
+    {
+        let t = self.value.replace_with(f);
+        self.transmit();
+        t
+    }
+
+    /// Access the model's receiver.
+    ///
+    /// The returned receiver can be used to subscribe to the model's updates.
+    pub fn recv(&self) -> &Receiver<T> {
+        &self.recv
+    }
+}
+
+impl<T: Clone + Default + 'static> Model<T> {
+    /// Takes the wrapped value, leaving Default::default() in its place.
+    pub fn take(&self) -> T {
+        let new_t = Default::default();
+        self.replace(new_t)
+    }
+}

--- a/mogwai/src/prelude.rs
+++ b/mogwai/src/prelude.rs
@@ -2,6 +2,7 @@
 pub use super::{
     component::{subscriber::Subscriber, *},
     gizmo::*,
+    model::*,
     txrx::{
         new_shared, recv, trns, txrx, txrx_filter_fold, txrx_filter_map, txrx_fold,
         txrx_fold_shared, txrx_map, wrap_future, Receiver, Transmitter,


### PR DESCRIPTION
* introduces `Model`, which can be used to update the view automatically when a wrapped value changes.
* adds `Subscriber<&ViewMsg>` to bind because sometimes it's needed.