### PR TITLE
Fix a broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ to do rendering. It is an alternative to React, Backbone, Ember, Elm, Purescript
 - [example](#example)
 - [intro](#introduction)
 - [why](#why)
-- [beginning](#ok---where-do-i-start?)
+- [beginning](#ok---where-do-i-start)
 - [more examples](#more-examples)
 - [cookbook](#cookbook)
 - [sponsor this project](#sponsorship)


### PR DESCRIPTION
Not very important, noticed thanks to a [crates.io issue](https://github.com/rust-lang/crates.io/issues/3108).

Edit for more context: without this patch, the link doesn't work on Github too.