### PR TITLE
v0.6.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
   "cookbook",
   "crates/mogwai",
+  "crates/mogwai-benches",
   "crates/mogwai-dom",
   "crates/mogwai-macros",
   "examples/counter",

--- a/crates/mogwai-benches/Cargo.toml
+++ b/crates/mogwai-benches/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "mogwai-benches"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.68"
+console_error_panic_hook = { version = "0.1.6" }
+console_log = "^0.1"
+getrandom = { version = "0.2", features = ["js"] }
+log = "^0.4"
+mogwai-dom = { path = "../mogwai-dom" }
+rand = { version = "0.8.5", features = ["small_rng"] }
+serde_json = "1.0.91"
+serde = { version = "1.0.152", features = ["derive"]}
+wasm-bindgen = "^0.2"
+wasm-bindgen-futures = "0.4.33"
+
+[dependencies.web-sys]
+version = "^0.3"
+features = [
+  "Element",
+  "Document",
+  "HtmlElement",
+  "HtmlCollection",
+  "HtmlBodyElement",
+  "NodeList",
+  "Storage"
+]

--- a/crates/mogwai-benches/index.html
+++ b/crates/mogwai-benches/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>Mogwai • Benchmarks</title>
+        <style>
+            .change-red {
+                font-weight: bold;
+                color: red;
+            }
+            .change-green {
+                font-weight: bold;
+                color: green;
+            }
+        </style>
+    </head>
+    <body>
+        <script type=module>
+        import init from './pkg/mogwai_benches.js';
+            window.addEventListener('load', async () => {
+                await init();
+            });
+        </script>
+    </body>
+</html>

--- a/crates/mogwai-benches/src/benches.rs
+++ b/crates/mogwai-benches/src/benches.rs
@@ -1,0 +1,336 @@
+use std::sync::{Arc, Mutex};
+
+use mogwai_dom::{core::model::*, prelude::*};
+use rand::prelude::*;
+use wasm_bindgen::JsCast;
+use web_sys::Element;
+
+static ADJECTIVES: &[&str] = &[
+    "pretty",
+    "large",
+    "big",
+    "small",
+    "tall",
+    "short",
+    "long",
+    "handsome",
+    "plain",
+    "quaint",
+    "clean",
+    "elegant",
+    "easy",
+    "angry",
+    "crazy",
+    "helpful",
+    "mushy",
+    "odd",
+    "unsightly",
+    "adorable",
+    "important",
+    "inexpensive",
+    "cheap",
+    "expensive",
+    "fancy",
+];
+
+static COLOURS: &[&str] = &[
+    "red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black",
+    "orange",
+];
+
+static NOUNS: &[&str] = &[
+    "table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger",
+    "pizza", "mouse", "keyboard",
+];
+
+type Id = usize;
+type Count = usize;
+type Step = usize;
+
+#[derive(Clone)]
+struct Row {
+    id: usize,
+    label: Model<String>,
+}
+
+fn build_data(count: usize, next_id: usize) -> Vec<Row> {
+    let mut thread_rng = thread_rng();
+
+    let mut data = Vec::new();
+    data.reserve_exact(count);
+
+    for inc in 0..count {
+        let id = next_id + inc;
+        let adjective = ADJECTIVES.choose(&mut thread_rng).unwrap();
+        let colour = COLOURS.choose(&mut thread_rng).unwrap();
+        let noun = NOUNS.choose(&mut thread_rng).unwrap();
+        let capacity = adjective.len() + colour.len() + noun.len() + 2;
+        let mut label = String::with_capacity(capacity);
+        label.push_str(adjective);
+        label.push(' ');
+        label.push_str(colour);
+        label.push(' ');
+        label.push_str(noun);
+        data.push(Row {
+            id,
+            label: Model::new(label),
+        });
+    }
+
+    data
+}
+
+#[derive(Clone)]
+enum Msg {
+    Create(Count),
+    Append(Count),
+    Update(Step),
+    Clear,
+    Swap,
+    Select(Id),
+    Remove(Id),
+}
+
+#[derive(Clone)]
+pub struct Mdl {
+    next_id: Arc<Mutex<usize>>,
+    selected: Model<Option<Id>>,
+    rows: ListPatchModel<Row>,
+}
+
+impl Default for Mdl {
+    fn default() -> Self {
+        let selected: Model<Option<Id>> = Model::new(None);
+        let rows: ListPatchModel<Row> = ListPatchModel::default();
+        let next_id = Arc::new(Mutex::new(1));
+        Self {
+            rows,
+            selected,
+            next_id,
+        }
+    }
+}
+
+impl Mdl {
+    // ------ ------
+    //    Update
+    // ------ ------
+    async fn update(&self, msg: Msg) {
+        match msg {
+            Msg::Create(cnt) => {
+                self.selected.visit_mut(|s| *s = None).await;
+                let new_rows = {
+                    let mut next_id = self.next_id.lock().unwrap();
+                    let rows = build_data(cnt, *next_id);
+                    *next_id += cnt;
+                    rows
+                };
+                for row in new_rows.into_iter() {
+                    self.rows.push(row).await.expect("could not create rows");
+                }
+                //self.rows.splice(.., new_rows).await.expect("could not create
+                // rows");
+            }
+            Msg::Append(cnt) => {
+                let new_rows = {
+                    let mut next_id = self.next_id.lock().unwrap();
+                    let rows = build_data(cnt, *next_id);
+                    *next_id += cnt;
+                    rows
+                };
+                let num_rows = self.rows.visit(Vec::len).await;
+                self.rows
+                    .splice(num_rows.., new_rows)
+                    .await
+                    .expect("could not append rows");
+            }
+            Msg::Update(step_size) => {
+                let rows = self.rows.read().await;
+                for row in rows.iter().step_by(step_size) {
+                    row.label.visit_mut(|l| l.push_str(" !!!")).await;
+                }
+            }
+            Msg::Clear => {
+                self.selected.visit_mut(|s| *s = None).await;
+                self.rows.drain().await.expect("could not patch");
+            }
+            Msg::Swap => {
+                let num_rows = self.rows.visit(Vec::len).await;
+                if num_rows > 998 {
+                    let row998 = self.rows.remove(998).await.expect("can't remove row 998");
+                    let row1 = self
+                        .rows
+                        .replace(1, row998)
+                        .await
+                        .expect("could not replace row 1 with previous 998");
+                    self.rows
+                        .insert(998, row1)
+                        .await
+                        .expect("could not insert row 1 into index 998");
+                }
+            }
+            Msg::Select(id) => {
+                self.selected.visit_mut(|s| *s = Some(id)).await;
+            }
+            Msg::Remove(remove_id) => {
+                let rows = self.rows.read().await;
+                let index = rows
+                    .iter()
+                    .enumerate()
+                    .find_map(|(i, row)| if row.id == remove_id { Some(i) } else { None })
+                    .unwrap();
+                drop(rows);
+                self.rows.remove(index).await.expect("could not patch");
+            }
+        }
+    }
+
+    // ------ ------
+    //     View
+    // ------ ------
+    pub fn viewbuilder(self) -> ViewBuilder {
+        let main_click = Output::<JsDomEvent>::default();
+        let selected = self.selected.clone();
+        let builder = rsx! (
+            div(id="main", on:click = main_click.sink()) {
+                div(class="container") {
+                    div(class="jumbotron") {
+                        div(class="row") {
+                            div(class="col-md-6") {
+                                h1(){"mogwai"}
+                            }
+                            div(class="col-md-6") {
+                                div(class="row") {
+                                    button(id="run")      { "Create 1,000 rows" }
+                                    button(id="runlots")  { "Create 10,000 rows" }
+                                    button(id="add")      { "Append 1,000 rows" }
+                                    button(id="update")   { "Update every 10th row" }
+                                    button(id="clear")    { "Clear" }
+                                    button(id="swaprows") { "Swap Rows" }
+                                }
+                            }
+                        }
+                    }
+                    table( class="table table-hover table-striped test-data") {
+                        tbody(patch:children = self.rows
+                            .stream()
+                            .map(move |patch|{
+                                patch.map(|row| {
+                                    let is_selected = selected.stream().map(move |selected| selected == Some(row.id));
+                                    let select_class = ("", is_selected.map(|is_selected| if is_selected{ "danger"} else { "" }.to_string()));
+
+                                    rsx!(
+                                        tr(key=row.id.to_string(), class = select_class) {
+                                            td(class="col-md-1"){{ row.id.to_string() }}
+                                            td(class="col-md-4"){
+                                                a() {{ ("", row.label.stream()) }}
+                                            }
+                                            td(class="col-md-1"){
+                                                a() {
+                                                    span(class="glyphicon glyphicon-remove", aria_hidden="true") {}
+                                                }
+                                            }
+                                            td(class="col-md-6"){ }
+                                        }
+                                    )
+                                })
+                            })
+                        ) {}
+                    }
+                }
+            }
+        );
+        builder.with_task(async move {
+            while let Some(ev) = main_click.get().await {
+                let may_msg = {
+                    let e = ev.browser_event().expect("not an event");
+                    let target = e
+                        .target()
+                        .expect("no target")
+                        .dyn_into::<Element>()
+                        .expect("target not an element");
+
+                    fn get_id(el: &Element) -> Option<Id> {
+                        let key = el.get_attribute("key")?;
+                        key.parse().ok()
+                    }
+
+                    if target.matches("#add").expect("can't match") {
+                        e.prevent_default();
+                        Some(Msg::Append(1000))
+                    } else if target.matches("#run").expect("can't match") {
+                        e.prevent_default();
+                        Some(Msg::Create(1000))
+                    } else if target.matches("#update").expect("can't match") {
+                        e.prevent_default();
+                        Some(Msg::Update(10))
+                    } else if target.matches("#hideall").expect("can't match") {
+                        e.prevent_default();
+                        None
+                    } else if target.matches("#showall").expect("can't match") {
+                        e.prevent_default();
+                        None
+                    } else if target.matches("#runlots").expect("can't match") {
+                        e.prevent_default();
+                        Some(Msg::Create(10_000))
+                    } else if target.matches("#clear").expect("can't match") {
+                        e.prevent_default();
+                        Some(Msg::Clear)
+                    } else if target.matches("#swaprows").expect("can't match") {
+                        e.prevent_default();
+                        Some(Msg::Swap)
+                    } else if target.matches(".remove").expect("can't match") {
+                        e.prevent_default();
+                        get_id(&target).map(Msg::Remove)
+                    } else if target.matches(".lbl").expect("can't match") {
+                        e.prevent_default();
+                        get_id(&target).map(Msg::Select)
+                    } else {
+                        None
+                    }
+                };
+
+                if let Some(msg) = may_msg {
+                    self.update(msg).await;
+                }
+            }
+        })
+    }
+}
+
+async fn mdl_create(count: usize, mdl: &Mdl, doc: &JsDom) -> f64 {
+    mdl.update(Msg::Create(count)).await;
+    let found = mogwai_dom::core::time::wait_for(20.0, || {
+        doc.clone_as::<web_sys::Document>()?
+            .query_selector(&format!(
+                "tbody>tr:nth-of-type({count})>td:nth-of-type(2)>a"
+            ))
+            .ok()
+            .flatten()
+    })
+    .await
+    .expect("cannot create");
+    found.elapsed_seconds
+}
+
+async fn mdl_clear(mdl: &Mdl, doc: &JsDom) -> f64 {
+    mdl.update(Msg::Clear).await;
+    let found = mogwai_dom::core::time::wait_for(3.0, || {
+        let trs = doc
+            .clone_as::<web_sys::Document>()?
+            .query_selector_all("tbody>tr")
+            .ok()?;
+        if trs.length() == 0 {
+            Some(())
+        } else {
+            None
+        }
+    })
+    .await
+    .expect("cannot clear");
+    found.elapsed_seconds
+}
+
+pub async fn create(mdl: &Mdl, doc: &JsDom, count: usize) -> f64 {
+    mdl_create(count, mdl, doc).await + mdl_clear(mdl, doc).await
+}

--- a/crates/mogwai-benches/src/lib.rs
+++ b/crates/mogwai-benches/src/lib.rs
@@ -1,0 +1,142 @@
+use mogwai_dom::prelude::*;
+use std::{future::Future, marker::PhantomData, panic};
+use wasm_bindgen::prelude::*;
+
+mod benches;
+mod store;
+
+struct Bench<F, Fut> {
+    name: &'static str,
+    // seconds
+    samples: Vec<f64>,
+    routine: F,
+    _phantom: PhantomData<Fut>,
+}
+
+impl<F, Fut> Bench<F, Fut>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = ()>,
+{
+    pub fn new(name: &'static str, routine: F) -> Self {
+        Bench {
+            name,
+            samples: vec![],
+            routine,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub async fn run(&mut self, mut warmups: usize, num_samples: usize) {
+        while self.samples.len() < num_samples {
+            let start_millis = mogwai_dom::core::time::now();
+            let fut = (self.routine)();
+            fut.await;
+            let end_millis = mogwai_dom::core::time::now();
+            if warmups > 0 {
+                warmups -= 1;
+            } else {
+                self.samples.push((end_millis - start_millis) / 1000.0);
+            }
+        }
+    }
+
+    pub fn average(&self) -> f64 {
+        self.samples.iter().sum::<f64>() / self.samples.len() as f64
+    }
+
+    pub fn save(&self) -> anyhow::Result<()> {
+        let to_store = store::StoredBench {
+            name: self.name.to_string(),
+            samples: self.samples.clone(),
+        };
+        to_store.try_write()
+    }
+
+    pub fn viewbuilder(&self) -> ViewBuilder {
+        rsx! {
+            fieldset() {
+                legend() { {self.name} }
+                dl() {
+                    dt() {"Average"}
+                    dd() { {format!("{}", self.average())} }
+                    {
+                        store::StoredBench::try_load(self.name).expect("storage problem").map(|prev| {
+                            let avg = self.average();
+                            let prev_avg = prev.average();
+                            let percent_change = 100.0 * (avg - prev_avg) / prev_avg;
+                            let change_class = if percent_change.abs() > 3.0 {
+                                if percent_change.signum() < 0.0 {
+                                    "change-green"
+                                } else {
+                                    "change-red"
+                                }
+                            } else {
+                                "change"
+                            };
+                            rsx!{
+                                slot() {
+                                    dt() { "Change" }
+                                    dd(class = change_class) {
+                                        {format!("{:0.03}%", percent_change)}
+                                    }
+                                }
+
+                            }
+                        })
+                    }
+                    {
+                        self.samples.iter().enumerate().map(|(i, time)| rsx!{
+                            slot(){
+                                dt() { {format!("{}", i)} }
+                                dd() { {format!("{:?}", time)} }
+                            }
+                        }).collect::<Vec<_>>()
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[wasm_bindgen(start)]
+pub fn main() -> Result<(), JsValue> {
+    panic::set_hook(Box::new(console_error_panic_hook::hook));
+    console_log::init_with_level(log::Level::Trace).expect("could not init console_log");
+
+    log::info!("creating Mdl");
+    let mdl = benches::Mdl::default();
+    let dom = JsDom::try_from(mdl.clone().viewbuilder()).unwrap();
+    dom.run().unwrap();
+
+    wasm_bindgen_futures::spawn_local(async move {
+        log::info!("creating and running benchmarks");
+
+        let doc = mogwai_dom::utils::document();
+        let mut create_1000 = Bench::new("create_1000", || async {
+            benches::create(&mdl, &doc, 1000).await;
+        });
+        let mut create_10_000 = Bench::new("create_10_000", || async {
+            benches::create(&mdl, &doc, 10_000).await;
+        });
+
+        create_1000.run(3, 7).await;
+        create_10_000.run(1, 2).await;
+
+        let stats = JsDom::try_from(rsx! {
+            fieldset(id = "results") {
+                legend() { "Results" }
+                {create_1000.viewbuilder()}
+                {create_10_000.viewbuilder()}
+            }
+        })
+        .expect("could not build stats");
+        stats.run().unwrap();
+        create_1000.save().expect("could not save result");
+        create_10_000.save().expect("could not save result");
+
+        log::info!("done!");
+    });
+
+    Ok(())
+}

--- a/crates/mogwai-benches/src/store.rs
+++ b/crates/mogwai-benches/src/store.rs
@@ -1,0 +1,49 @@
+use anyhow::Context;
+use mogwai_dom::utils;
+use serde::{Deserialize, Serialize};
+use web_sys::Storage;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StoredBench {
+    pub name: String,
+    pub samples: Vec<f64>,
+}
+
+impl StoredBench {
+    fn key(&self) -> String {
+        self.name.clone()
+    }
+
+    pub fn try_load(name: impl ToString) -> anyhow::Result<Option<Self>> {
+        let storage = utils::window()
+            .local_storage()
+            .map_err(|jsv| anyhow::anyhow!("could not get local storage: {:#?}", jsv))?
+            .context("no storage")?;
+        let key = name.to_string();
+        if let Some(s) = storage.get_item(&key).ok().context("storage problem")? {
+            let stored_bench: StoredBench = serde_json::from_str(&s)?;
+            Ok(Some(stored_bench))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn try_write(&self) -> anyhow::Result<()> {
+        let str_value = serde_json::to_string(&self)?;
+        let key = self.key();
+        utils::window()
+            .local_storage()
+            .map_err(|jsv| anyhow::anyhow!("could not get local storage: {:#?}", jsv))?
+            .into_iter()
+            .for_each(|storage: Storage| {
+                storage
+                    .set_item(&key, &str_value)
+                    .expect("could not store serialized items");
+            });
+        Ok(())
+    }
+
+    pub fn average(&self) -> f64 {
+        self.samples.iter().sum::<f64>() / self.samples.len() as f64
+    }
+}

--- a/crates/mogwai-dom/Cargo.toml
+++ b/crates/mogwai-dom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mogwai-dom"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Schell Scivally <efsubenovex@gmail.com>"]
 license = "MIT"
@@ -21,7 +21,7 @@ async-executor = "1.5.0"
 async-lock = "2.6.0"
 futures = "^0.3"
 log = "^0.4"
-mogwai = { version = "0.6.1", path = "../mogwai" }
+mogwai = { version = "0.6.2", path = "../mogwai" }
 mogwai-macros = { version = "0.1.0", path = "../mogwai-macros", features = ["dom"] }
 send_wrapper = "^0.6"
 serde = { version = "^1.0", features = ["derive"] }

--- a/crates/mogwai-dom/Cargo.toml
+++ b/crates/mogwai-dom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mogwai-dom"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["Schell Scivally <efsubenovex@gmail.com>"]
 license = "MIT"
@@ -20,8 +20,9 @@ async-channel = "1.8.0"
 async-executor = "1.5.0"
 async-lock = "2.6.0"
 futures = "^0.3"
+lazy_static = "1.4.0"
 log = "^0.4"
-mogwai = { version = "0.6.2", path = "../mogwai" }
+mogwai = { version = "0.6.3", path = "../mogwai" }
 mogwai-macros = { version = "0.1.0", path = "../mogwai-macros", features = ["dom"] }
 send_wrapper = "^0.6"
 serde = { version = "^1.0", features = ["derive"] }

--- a/crates/mogwai/Cargo.toml
+++ b/crates/mogwai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mogwai"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 authors = ["Schell Scivally <efsubenovex@gmail.com>"]
 license = "MIT"

--- a/crates/mogwai/src/time.rs
+++ b/crates/mogwai/src/time.rs
@@ -206,11 +206,9 @@ pub async fn wait_one_frame() {
     {
         let (tx, rx) = async_channel::bounded::<()>(1);
         set_immediate(move || {
-            tx.try_send(()).ok().unwrap();
+            let _ = tx.try_send(());
         });
-        // UNWRAP: safe because we control both sides of the channel and we know
-        // the closure above sends a value.
-        rx.recv().await.unwrap();
+        let _ = rx.recv().await;
     }
     #[cfg(not(target_arch = "wasm32"))]
     {


### PR DESCRIPTION
* includes some rudimentary benchmarks for the `js-framework-benchmark` project.
* removed strings used for debugging
* events are optimized a bit (we spawn 1/2 as many async loops now) 
* `exhaust` uses a static dummy waker (`exhaust` needs more work though)